### PR TITLE
Version 0.22 - Blender 3.0 support

### DIFF
--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -12,7 +12,7 @@ bl_info = {
     "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "002"
+mustardui_buildnum = "003"
 
 import bpy
 import addon_utils
@@ -26,7 +26,7 @@ import itertools
 from bpy.types import Header, Menu, Panel
 from bpy.props import *
 from bpy.app.handlers import persistent
-from rna_prop_ui import rna_idprop_ui_create, rna_idprop_ui_prop_update
+from rna_prop_ui import rna_idprop_ui_create
 from mathutils import Vector, Color
 import webbrowser
 

--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -6,13 +6,13 @@ bl_info = {
     "name": "MustardUI",
     "description": "Create a MustardUI for a human character.",
     "author": "Mustard",
-    "version": (0, 21, 0),
-    "blender": (2, 93, 0),
+    "version": (0, 22, 0),
+    "blender": (3, 0, 0),
     "warning": "",
-    "wiki_url": "https://github.com/Mustard2/MustardUI",
+    "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "013"
+mustardui_buildnum = "001"
 
 import bpy
 import addon_utils
@@ -26,6 +26,7 @@ import itertools
 from bpy.types import Header, Menu, Panel
 from bpy.props import *
 from bpy.app.handlers import persistent
+from rna_prop_ui import rna_idprop_ui_create
 from rna_prop_ui import rna_idprop_value_item_type
 from mathutils import Vector, Color
 import webbrowser
@@ -1371,33 +1372,13 @@ class MustardUI_CustomProperty(bpy.types.PropertyGroup):
                         update = update_bool_value,
                         description = "")
     
-    # Color value show
-    def update_color_value(self, context):
-        
-        settings = bpy.context.scene.MustardUI_Settings
-        res, obj = mustardui_active_object(context, config = 0)
-        
-        if obj != None:
-            
-            obj[self.prop_name] = self.color_value
-        
-        return
-    
-    color_value: bpy.props.FloatVectorProperty(name = "",
-                        update = update_color_value,
-                        size = 4,
-                        subtype = "COLOR",
-                        min = 0., max = 1.,
-                        default = [0.,0.,0.,1.],
-                        description = "")
-    
     # User defined properties
     name : bpy.props.StringProperty(name = "Custom property name")
     icon : bpy.props.EnumProperty(name='Icon',
                         description="Choose the icon",
                         items = mustardui_icon_list)
     
-    # Properties stored to rebuild UI_RNA in case of troubles
+    # Properties stored to rebuild custom properties in case of troubles
     description: bpy.props.StringProperty()
     default_int: bpy.props.IntProperty()
     min_int: bpy.props.IntProperty()
@@ -1538,11 +1519,13 @@ def mustardui_clean_prop(obj, uilist, index, settings):
         
         # Delete custom property and drivers
         try:
-            del obj["_RNA_UI"][uilist[index].prop_name]
+            ui_data = obj.id_properties_ui(uilist[index].prop_name)
+            ui_data.clear()
         except:
             if settings.debug:
-                print('MustardUI - RNA_UI not found for this property. Skipping custom properties deletion')
+                print('MustardUI - Could not clear UI properties. Skipping for this custom property')
         
+        # Delete custom property
         try:
             del obj[uilist[index].prop_name]
         except:
@@ -1624,10 +1607,6 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             self.report({'ERROR'}, 'MustardUI - This property was already added.')
             return {'FINISHED'}
         
-        # Check if RNA_UI is available, otherwise build
-        if "_RNA_UI" not in obj.keys():
-            obj["_RNA_UI"] = {}
-        
         # Try to find a better name than default_value for material nodes
         if "node_tree.nodes" in rna:
             rna_node = rna.rsplit(".", 1)
@@ -1649,21 +1628,23 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             while prop_name in obj.keys():
                 add_string_num += 1
                 prop_name = prop_name_ui + ' ' + str(add_string_num)
-            obj[prop_name] = eval(rna + '.' + path)
-            
-            obj.property_overridable_library_set('["'+ prop_name +'"]', True)
             
             # Change custom properties settings
             if prop.type == "BOOLEAN":
-                obj["_RNA_UI"][prop_name] = {'min':0, 'max':1, 'description': prop.description, 'default': prop.default}
+                rna_idprop_ui_create(obj, prop_name, default=eval(rna + '.' + path),
+                                    description=prop.description,
+                                    overridable=True)
             elif hasattr(prop, 'hard_min') and hasattr(prop, 'hard_max') and hasattr(prop, 'default') and hasattr(prop, 'description') and hasattr(prop, 'subtype'):
                 description = prop.description if not "materials" in rna else ""
-                if prop.subtype != "FACTOR":
-                    obj["_RNA_UI"][prop_name] = {'min':prop.hard_min if prop.subtype != "COLOR" else 0, 'max':prop.hard_max if prop.subtype != "COLOR" else 1, 'description': description, 'default': prop.default if prop.array_length == 0 else eval(rna + '.' + path), 'subtype': prop.subtype}
-                else:
-                    obj["_RNA_UI"][prop_name] = {'min':prop.hard_min, 'max':prop.hard_max, 'description': description, 'default': prop.default if prop.array_length == 0 else eval(rna + '.' + path), 'subtype': "NONE"}
+                rna_idprop_ui_create(obj, prop_name, default=prop.default if prop.array_length == 0 else eval(rna + '.' + path),
+                                    min=prop.hard_min if prop.subtype != "COLOR" else 0,
+                                    max=prop.hard_max if prop.subtype != "COLOR" else 1,
+                                    description=description,
+                                    overridable=True,
+                                    subtype=prop.subtype if prop.subtype != "FACTOR" else None)
             elif hasattr(prop, 'description'):
-                obj["_RNA_UI"][prop_name] = {'description': prop.description}
+                rna_idprop_ui_create(obj, prop_name, default=eval(rna + '.' + path),
+                                    description=prop.description)
         
         # Add driver
         force_non_animatable = False
@@ -1674,7 +1655,10 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             force_non_animatable = True
         
         # Add property to the collection of properties
-        if not rna in [x.rna for x in custom_props] or not path in [x.path for x in custom_props]:
+        if not (rna,path) in [(x.rna,x.path) for x in custom_props]:
+            
+            ui_data_dict = obj.id_properties_ui(prop_name).as_dict()
+            
             cp = custom_props.add()
             cp.rna = rna
             cp.path = path
@@ -1693,8 +1677,6 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             cp.is_bool = prop.type == "BOOLEAN"
             if prop.type == "BOOLEAN":
                 cp.bool_value = eval(rna + '.' + path)
-            if prop.subtype == "COLOR":
-                cp.color_value = eval(rna + '.' + path)
             cp.is_animatable = prop.is_animatable if not force_non_animatable else False
             
             cp.section = self.section
@@ -1717,26 +1699,30 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             
             if prop.is_animatable:
                 if hasattr(prop, 'description'):
-                    cp.description = obj["_RNA_UI"][prop_name]['description']
+                    cp.description = prop.description
                 if hasattr(prop, 'default'):
                     if prop.array_length == 0:
                         if prop.type == "FLOAT":
-                            cp.default_float = obj["_RNA_UI"][prop_name]['default']
+                            cp.default_float = prop.default
                         elif prop.type == "INT" or prop.type == "BOOLEAN":
-                            cp.default_int = obj["_RNA_UI"][prop_name]['default']
+                            cp.default_int = prop.default
                     else:
-                        cp.default_array = str(obj["_RNA_UI"][prop_name]['default'].to_list())
+                        cp.default_array = str(ui_data_dict['default'])
+                        print(cp.default_array)
                         
                 if hasattr(prop, 'hard_min') and prop.type != "BOOLEAN":
                     if prop.type == "FLOAT":
-                        cp.min_float = obj["_RNA_UI"][prop_name]['min']
+                        cp.min_float = prop.hard_min
                     elif prop.type == "INT":
-                        cp.min_int = obj["_RNA_UI"][prop_name]['min']
+                        cp.min_int = prop.hard_min
                 if hasattr(prop, 'hard_max') and prop.type != "BOOLEAN":
                     if prop.type == "FLOAT":
-                        cp.max_float = obj["_RNA_UI"][prop_name]['max']
+                        cp.max_float = prop.hard_max
                     elif prop.type == "INT":
-                        cp.max_int = obj["_RNA_UI"][prop_name]['max']
+                        cp.max_int = prop.hard_max
+        else:
+            self.report({'ERROR'}, 'MustardUI - An error occurred while adding the property to the custom properties list.')
+            return {'FINISHED'}
         
         # Update the drivers
         obj.update_tag()
@@ -2088,12 +2074,11 @@ class MUSTARDUI_UL_Property_UIList(bpy.types.UIList):
                 else:
                     row.label(text="", icon="BLANK1")
                 
-                if "_RNA_UI" not in obj.keys():
-                    row.label(text="", icon="ERROR")
-                elif item.prop_name not in obj["_RNA_UI"].keys():
-                    row.label(text="", icon="ERROR")
-                else:
+                try:
+                    obj.id_properties_ui(item.prop_name)
                     row.label(text="", icon="BLANK1")
+                except:
+                    row.label(text="", icon="ERROR")
             
             if item.section == "":
                 row.label(text="", icon = "LIBRARY_DATA_BROKEN")
@@ -2143,12 +2128,11 @@ class MUSTARDUI_UL_Property_UIListOutfits(bpy.types.UIList):
                 else:
                     row.label(text="", icon="BLANK1")
                 
-                if "_RNA_UI" not in obj.keys():
-                    row.label(text="", icon="ERROR")
-                elif item.prop_name not in obj["_RNA_UI"].keys():
-                    row.label(text="", icon="ERROR")
-                else:
+                try:
+                    obj.id_properties_ui(item.prop_name)
                     row.label(text="", icon="BLANK1")
+                except:
+                    row.label(text="", icon="ERROR")
             
             if len(item.linked_properties) > 0:
                 row.label(text="", icon="LINK_BLEND")
@@ -2188,12 +2172,11 @@ class MUSTARDUI_UL_Property_UIListHair(bpy.types.UIList):
                 else:
                     row.label(text="", icon="BLANK1")
                 
-                if "_RNA_UI" not in obj.keys():
-                    row.label(text="", icon="ERROR")
-                elif item.prop_name not in obj["_RNA_UI"].keys():
-                    row.label(text="", icon="ERROR")
-                else:
+                try:
+                    obj.id_properties_ui(item.prop_name)
                     row.label(text="", icon="BLANK1")
+                except:
+                    row.label(text="", icon="ERROR")
             
             if len(item.linked_properties) > 0:
                 row.label(text="", icon="LINK_BLEND")
@@ -2315,23 +2298,6 @@ class MustardUI_Property_Settings(bpy.types.Operator):
         res, obj = mustardui_active_object(context, config = 1)
         return obj != None
     
-    def restore_RNA_UI(self, custom_prop, prop_type, settings):
-        
-        if settings.debug:
-            print("MustardUI: Restoring RNA_UI")
-        
-        self.description = custom_prop.description
-        if not custom_prop.is_bool and prop_type == float and custom_prop.force_type == "None":
-            self.max_int = custom_prop.max_int
-            self.min_int = custom_prop.min_int
-            self.default_int = custom_prop.default_int if custom_prop.array_length == 0 else eval(custom_prop.default_array)
-        elif not custom_prop.is_bool and (prop_type == int or custom_prop.force_type == "Int"):
-            self.max_float = custom_prop.max_float
-            self.min_float = custom_prop.min_float
-            self.default_float = custom_prop.default_float if custom_prop.array_length == 0 else eval(custom_prop.default_array)
-        
-        return
-    
     def execute(self, context):
         
         settings = bpy.context.scene.MustardUI_Settings
@@ -2353,6 +2319,11 @@ class MustardUI_Property_Settings(bpy.types.Operator):
             self.report({'ERROR'}, 'MustardUI - Can not change default with different vector dimension.')
             return {'FINISHED'}
         
+        prop_name = custom_prop.prop_name
+        
+        ui_data = obj.id_properties_ui(prop_name)
+        ui_data_dict = ui_data.as_dict()
+        
         custom_prop.name = self.name
         custom_prop.icon = self.icon
         
@@ -2360,24 +2331,21 @@ class MustardUI_Property_Settings(bpy.types.Operator):
             
             prop_name = custom_prop.prop_name
             prop_array = custom_prop.array_length > 0
+            prop_subtype = custom_prop.subtype
             
-            custom_prop.force_type = self.force_type
+            ui_data = obj.id_properties_ui(prop_name)
             
             custom_prop.is_bool = self.force_type == "Bool" or custom_prop.type == "BOOLEAN"
             
-            if "_RNA_UI" not in obj.keys():
-                obj["_RNA_UI"] = {}
-            
             if custom_prop.is_bool:
-                obj["_RNA_UI"][prop_name] = {'min':0, 'max':1}
+                ui_data.update(min=0,max=1)
                 obj[prop_name] = min(1,max(0,int(obj[prop_name])))
             elif not custom_prop.is_bool and prop_type == "FLOAT" and self.force_type == "None":
-                if custom_prop.subtype == "FACTOR":
-                    obj["_RNA_UI"][prop_name] = {'min': self.min_float, 'max': self.max_float, 'description': self.description, 'default': self.default_float if custom_prop.array_length == 0 else eval(self.default_array)}
-                elif custom_prop.subtype == "COLOR":
-                    obj["_RNA_UI"][prop_name] = {'min': 0., 'max': 1.}
-                else:
-                    obj["_RNA_UI"][prop_name] = {'min': self.min_float, 'max': self.max_float, 'description': self.description, 'default': self.default_float if custom_prop.array_length == 0 else eval(self.default_array), 'subtype': custom_prop.subtype}
+                ui_data.update(min = self.min_float if prop_subtype != "COLOR" else 0.,
+                                max = self.max_float if prop_subtype != "COLOR" else 1.,
+                                description = self.description,
+                                default = self.default_float if custom_prop.array_length == 0 else eval(self.default_array),
+                                subtype = custom_prop.subtype if prop_subtype != "FACTOR" else None)
                 custom_prop.description = self.description
                 custom_prop.min_float = self.min_float
                 custom_prop.max_float = self.max_float
@@ -2388,10 +2356,11 @@ class MustardUI_Property_Settings(bpy.types.Operator):
                     custom_prop.default_array = self.default_array
                 custom_prop.is_bool = False
             elif not custom_prop.is_bool and (prop_type == "INT" or self.force_type == "Int"):
-                if custom_prop.subtype != "FACTOR":
-                    obj["_RNA_UI"][prop_name] = {'min': self.min_int, 'max': self.max_int, 'description': self.description, 'default': self.default_int if custom_prop.array_length == 0 else eval(self.default_array), 'subtype': custom_prop.subtype}
-                else:
-                    obj["_RNA_UI"][prop_name] = {'min': self.min_int, 'max': self.max_int, 'description': self.description, 'default': self.default_int if custom_prop.array_length == 0 else eval(self.default_array)}
+                ui_data.update(min = self.min_int,
+                                max = self.max_int,
+                                description = self.description,
+                                default = self.default_int if custom_prop.array_length == 0 else eval(self.default_array),
+                                subtype = custom_prop.subtype if prop_subtype != "FACTOR" else None)
                 custom_prop.description = self.description
                 custom_prop.min_int = self.min_int
                 custom_prop.max_int = self.max_int
@@ -2402,7 +2371,7 @@ class MustardUI_Property_Settings(bpy.types.Operator):
                     custom_prop.default_array = self.default_array
                 custom_prop.is_bool = False
             else:
-                obj["_RNA_UI"][prop_name] = {'description': custom_prop.description}
+                ui_data.update(description = custom_prop.description)
                 custom_prop.description = self.description
         
         return {'FINISHED'}
@@ -2430,29 +2399,30 @@ class MustardUI_Property_Settings(bpy.types.Operator):
             prop_type = custom_prop.type
             self.force_type = custom_prop.force_type
             
-            if "_RNA_UI" in obj.keys():
-                if custom_prop.prop_name in obj["_RNA_UI"].keys():
-                    if not custom_prop.is_bool and (prop_type == "INT" or self.force_type == "Int"):
-                        self.max_int = obj["_RNA_UI"][custom_prop.prop_name]['max']
-                        self.min_int = obj["_RNA_UI"][custom_prop.prop_name]['min']
-                        if custom_prop.array_length == 0:
-                            self.default_int = obj["_RNA_UI"][custom_prop.prop_name]['default']
-                        else:
-                            self.default_array = str(obj["_RNA_UI"][custom_prop.prop_name]['default'].to_list())
-                    elif not custom_prop.is_bool and prop_type == "FLOAT" and self.force_type == "None":
-                        self.max_float = obj["_RNA_UI"][custom_prop.prop_name]['max']
-                        self.min_float = obj["_RNA_UI"][custom_prop.prop_name]['min']
-                        if self.min_float == self.max_float:
-                            self.max_float += 1
-                        if custom_prop.array_length > 0:
-                            if custom_prop.subtype != "COLOR":
-                                self.default_array = str(obj["_RNA_UI"][custom_prop.prop_name]['default'].to_list())
-                        else:
-                            self.default_float = obj["_RNA_UI"][custom_prop.prop_name]['default']
+            try:
+                ui_data = obj.id_properties_ui(custom_prop.prop_name)
+                ui_data_dict = ui_data.as_dict()
+            except:
+                self.report({'ERROR'}, 'MustardUI - An error occurred while retrieving UI data. Try to rebuild properties to solve this')
+                return {'FINISHED'}
+            
+            if not custom_prop.is_bool and (prop_type == "INT" or self.force_type == "Int"):
+                self.max_int = ui_data_dict['max']
+                self.min_int = ui_data_dict['min']
+                if custom_prop.array_length == 0:
+                    self.default_int = ui_data_dict['default']
                 else:
-                    self.restore_RNA_UI(custom_prop, prop_type)
-            else:
-                self.restore_RNA_UI(custom_prop, prop_type)
+                    self.default_array = str(ui_data_dict['default'].to_list())
+            elif not custom_prop.is_bool and prop_type == "FLOAT" and self.force_type == "None":
+                self.max_float = ui_data_dict['max']
+                self.min_float = ui_data_dict['min']
+                if self.min_float == self.max_float:
+                    self.max_float += 1
+                if custom_prop.array_length > 0:
+                    if custom_prop.subtype != "COLOR":
+                        self.default_array = str(ui_data_dict['default'].to_list())
+                else:
+                    self.default_float = ui_data_dict['default']
         
         return context.window_manager.invoke_props_dialog(self, width = 550 if settings.debug else 350)
             
@@ -2501,15 +2471,9 @@ class MustardUI_Property_Settings(bpy.types.Operator):
         
         if custom_prop.is_animatable:
             
-            # Debug mode
-            if "_RNA_UI" not in obj.keys():
-                box.label(text="Restoring RNA_UI", icon="ERROR")
-            elif custom_prop.prop_name not in obj["_RNA_UI"].keys():
-                box.label(text="Restoring RNA_UI", icon="ERROR")
-            
             prop_type = custom_prop.type
             
-            if not custom_prop.is_bool and custom_prop.subtype != "COLOR":
+            if not custom_prop.is_bool:
                 
                 box = layout.box()
             
@@ -2518,7 +2482,7 @@ class MustardUI_Property_Settings(bpy.types.Operator):
                 row.scale_x=scale
                 row.prop(self, "description", text="")
                 
-                if prop_type == "FLOAT":
+                if prop_type == "FLOAT" and custom_prop.subtype != "COLOR":
                     
                     if custom_prop.array_length == 0:
                         row=box.row()
@@ -2532,13 +2496,11 @@ class MustardUI_Property_Settings(bpy.types.Operator):
                             row.label(text="Default:")
                             row.scale_x=scale
                             row.prop(self, "default_float", text="")
-                    
-                    elif custom_prop.subtype != "COLOR":
                         
-                        row=box.row()
-                        row.label(text="Default:")
-                        row.scale_x=scale
-                        row.prop(self, "default_array", text="")
+                    row=box.row()
+                    row.label(text="Default:")
+                    row.scale_x=scale
+                    row.prop(self, "default_array", text="")
                     
                     if self.force_type == "None":
                         
@@ -2697,10 +2659,6 @@ class MustardUI_Property_Rebuild(bpy.types.Operator):
             custom_props.append((x,2))
         
         errors = 0
-        
-        # Rebuilding custom properties max/min/default/description
-        if "_RNA_UI" not in obj.keys():
-            obj["_RNA_UI"] = {}
             
         for custom_prop, prop_type in [x for x in custom_props if x[0].is_animatable]:
             
@@ -2709,40 +2667,36 @@ class MustardUI_Property_Rebuild(bpy.types.Operator):
             if prop_name in obj.keys():
                 del obj[prop_name]
             
-            # Rebuilding RNA_UI
             if custom_prop.is_bool or custom_prop.force_type == "Bool":
-                obj["_RNA_UI"][prop_name] = {'min':0, 'max':1}
-                obj[prop_name] = int(eval(custom_prop.rna + '.' + custom_prop.path))
+                rna_idprop_ui_create(obj, prop_name, default=int(eval(custom_prop.rna + '.' + custom_prop.path)),
+                                    min=0,
+                                    max=1,
+                                    description=custom_prop.description,
+                                    overridable=True)
+            
             elif not custom_prop.is_bool and custom_prop.type == "FLOAT" and custom_prop.force_type == "None":
-                if custom_prop.array_length == 0:
-                    obj[prop_name] = custom_prop.default_float
-                else:
-                    obj[prop_name] = eval(custom_prop.default_array)
-                    if custom_prop.subtype == "COLOR":
-                        try:
-                            custom_prop.color_value = eval(custom_prop.default_array)
-                        except:
-                            custom_prop.color_value = [0.,0.,0.,1.]
-                            custom_prop.default_array = "[0.,0.,0.,1.]"
-                if custom_prop.subtype != "FACTOR":
-                    obj["_RNA_UI"][prop_name] = {'min': custom_prop.min_float if custom_prop.subtype != "COLOR" else 0., 'max': custom_prop.max_float if custom_prop.subtype != "COLOR" else 1., 'description': custom_prop.description, 'default': custom_prop.default_float if custom_prop.array_length == 0 else eval(custom_prop.default_array), 'subtype': custom_prop.subtype}
-                else:
-                    obj["_RNA_UI"][prop_name] = {'min': custom_prop.min_float if custom_prop.subtype != "COLOR" else 0., 'max': custom_prop.max_float if custom_prop.subtype != "COLOR" else 1., 'description': custom_prop.description, 'default': custom_prop.default_float if custom_prop.array_length == 0 else eval(custom_prop.default_array)}
+                rna_idprop_ui_create(obj, prop_name,
+                                    default=custom_prop.default_float if custom_prop.array_length == 0 else eval(custom_prop.default_array),
+                                    min=custom_prop.min_float if custom_prop.subtype != "COLOR" else 0.,
+                                    max=custom_prop.max_float if custom_prop.subtype != "COLOR" else 1.,
+                                    description=custom_prop.description,
+                                    overridable=True,
+                                    subtype=custom_prop.subtype if custom_prop.subtype != "FACTOR" else None)
                             
             elif not custom_prop.is_bool and (custom_prop.type == "INT" or custom_prop.force_type == "Int"):
-                if custom_prop.subtype != "FACTOR":
-                    obj["_RNA_UI"][prop_name] = {'min': custom_prop.min_int, 'max': custom_prop.max_int, 'description': custom_prop.description, 'default': custom_prop.default_int if custom_prop.array_length == 0 else eval(custom_prop.default_array), 'subtype': custom_prop.subtype}
-                else:
-                    obj["_RNA_UI"][prop_name] = {'min': custom_prop.min_int, 'max': custom_prop.max_int, 'description': custom_prop.description, 'default': custom_prop.default_int if custom_prop.array_length == 0 else eval(custom_prop.default_array)}
-                if custom_prop.array_length == 0:
-                    obj[prop_name] = int(custom_prop.default_int)
-                else:
-                    obj[prop_name] = eval(custom_prop.default_array)
-            else:
-                obj["_RNA_UI"][prop_name] = {'description': custom_prop.description}
-                obj[prop_name] = eval(custom_prop.rna + '.' + custom_prop.path)
+                rna_idprop_ui_create(obj, prop_name,
+                                    default=int(custom_prop.default_int) if custom_prop.array_length == 0 else eval(custom_prop.default_array),
+                                    min=custom_prop.min_int,
+                                    max=custom_prop.max_int,
+                                    description=custom_prop.description,
+                                    overridable=True,
+                                    subtype=custom_prop.subtype if custom_prop.subtype != "FACTOR" else None)
             
-            obj.property_overridable_library_set('["'+ prop_name +'"]', True)
+            else:
+                rna_idprop_ui_create(obj, prop_name,
+                                    default=eval(custom_prop.rna + '.' + custom_prop.path),
+                                    description=custom_prop.description,
+                                    overridable=True)
             
             # Rebuilding custom properties and their linked properties drivers
             try:
@@ -2847,7 +2801,7 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
     
     def add_custom_property(self, obj, rna, path, name, type, custom_props, sections_to_recover):
         
-        # Check if the property was already added
+        # Check if the property was already added. If yes, link it to the one already added
         for cp in custom_props:
             if cp.rna == rna and cp.path == path:
                 if cp.prop_name in obj.keys():
@@ -2855,10 +2809,6 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
             if cp.name == name:
                 self.link_property(obj, rna, path, cp, custom_props)
                 return
-        
-        # Check if RNA_UI is available, otherwise build
-        if "_RNA_UI" not in obj.keys():
-            obj["_RNA_UI"] = {}
         
         # Add custom property to the object
         prop_name = name
@@ -2871,26 +2821,27 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
         obj[prop_name] = eval(rna + "." + path)
         
         # Change custom properties settings
-        if type == "BOOLEAN":
-            obj["_RNA_UI"][prop_name] = {}
-        elif type == "COLOR":
-            obj["_RNA_UI"][prop_name] = {'min':0., 'max':1., 'use_soft_limits':True, 'soft_min':0, 'soft_max':1, 'description': "", 'default': eval(rna + "." + path), 'subtype': "COLOR"}
-        elif type == "FLOAT":
-            obj["_RNA_UI"][prop_name] = {'min':0., 'max':1., 'description': "", 'default': eval(rna + "." + path)}
-        else:
-            obj["_RNA_UI"][prop_name] = {'min':0, 'max':1, 'description': "", 'default': int(eval(rna + "." + path))}
+        rna_idprop_ui_create(obj, prop_name,
+                            default=int(eval(rna + "." + path)) if type in ["INT", "BOOLEAN"] else eval(rna + "." + path),
+                            min=0 if type in ["INT", "BOOLEAN"] else 0.,
+                            max=1 if type in ["INT", "BOOLEAN"] else 1.,
+                            overridable=True,
+                            subtype="COLOR" if type == "COLOR" else None)
         
         # Add driver
         try:
             self.add_driver(obj, rna, path, prop_name)
         except:
             print("MustardUI - Could not add a driver for " + prop_name)
-            del obj["_RNA_UI"][prop_name]
             del obj[prop_name]
             return
         
         # Add property to the collection of properties
-        if not rna in [x.rna for x in custom_props] or not path in [x.path for x in custom_props]:
+        if not (rna,path) in [(x.rna,x.path) for x in custom_props]:
+            
+            ui_data = obj.id_properties_ui(prop_name)
+            ui_data_dict = ui_data.as_dict()
+            
             cp = custom_props.add()
             cp.rna = rna
             cp.path = path
@@ -2903,8 +2854,6 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
             cp.is_bool = type == "BOOLEAN"
             if cp.is_bool:
                 cp.bool_value = int(eval(rna + '.' + path))
-            if cp.subtype == "COLOR":
-                cp.color_value = eval(rna + '.' + path)
             
             cp.is_animatable = True
             for cptr in sections_to_recover:
@@ -2912,25 +2861,27 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
                     cp.section = cptr[2]
                     break
             
-            if 'description' in obj["_RNA_UI"][prop_name].keys():
-                cp.description = obj["_RNA_UI"][prop_name]['description']
-            if 'default' in obj["_RNA_UI"][prop_name].keys() and type != "BOOLEAN":
+            ui_data = obj.pr
+            
+            if 'description' in ui_data_dict.keys():
+                cp.description = ui_data_dict['description']
+            if 'default' in ui_data_dict.keys() and type != "BOOLEAN":
                 if type == "FLOAT":
-                    cp.default_float = obj["_RNA_UI"][prop_name]['default']
+                    cp.default_float = ui_data_dict['default']
                 elif type == "INT":
-                    cp.default_int = obj["_RNA_UI"][prop_name]['default']
+                    cp.default_int = ui_data_dict['default']
                 else:
-                    cp.default_array = str(obj["_RNA_UI"][prop_name]['default'].to_list())
-            if 'min' in obj["_RNA_UI"][prop_name].keys() and type != "BOOLEAN":
+                    cp.default_array = str(ui_data_dict['default'])
+            if 'min' in ui_data_dict.keys() and type != "BOOLEAN":
                 if type == "FLOAT":
-                    cp.min_float = obj["_RNA_UI"][prop_name]['min']
+                    cp.min_float = ui_data_dict['min']
                 elif type == "INT":
-                    cp.min_int = obj["_RNA_UI"][prop_name]['min']
-            if 'max' in obj["_RNA_UI"][prop_name].keys() and type != "BOOLEAN":
+                    cp.min_int = ui_data_dict['min']
+            if 'max' in ui_data_dict.keys() and type != "BOOLEAN":
                 if type == "FLOAT":
-                    cp.max_float = obj["_RNA_UI"][prop_name]['max']
+                    cp.max_float = ui_data_dict['max']
                 elif type == "INT":
-                    cp.max_int = obj["_RNA_UI"][prop_name]['max']
+                    cp.max_int = ui_data_dict['max']
         
         obj.property_overridable_library_set('["'+ prop_name +'"]', True)
         
@@ -6449,12 +6400,13 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
                         row.label(text=prop.name)
                     if prop.is_bool and prop.is_animatable:
                         row.prop(prop, 'bool_value', text="")
-                    elif prop.subtype == "COLOR" and prop.is_animatable:
-                        row.prop(prop, 'color_value', text="")
                     elif not prop.is_animatable:
                         row.prop(eval(prop.rna), prop.path, text="")
                     else:
-                        row.prop(obj, '["' + prop.prop_name + '"]', text="")
+                        if prop.prop_name in obj.keys():
+                            row.prop(obj, '["' + prop.prop_name + '"]', text="")
+                        else:
+                            row.prop(settings, 'custom_properties_error', icon = "ERROR", text="", icon_only = True, emboss = False)
                      
             for i_sec in sorted([x for x in range(0,len(rig_settings.body_custom_properties_sections))], key = lambda x:rig_settings.body_custom_properties_sections[x].id):
                 section = rig_settings.body_custom_properties_sections[i_sec]
@@ -6480,15 +6432,10 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
                                 row.label(text=prop.name)
                             if prop.is_bool and prop.is_animatable:
                                 row.prop(prop, 'bool_value', text="")
-                            elif prop.subtype == "COLOR" and prop.is_animatable:
-                                row.prop(prop, 'color_value', text="")
                             elif not prop.is_animatable:
                                 row.prop(eval(prop.rna), prop.path, text="")
                             else:
-                                if prop.prop_name in obj.keys():
-                                    row.prop(obj, '["' + prop.prop_name + '"]', text="")
-                                else:
-                                    row.prop(settings, 'custom_properties_error', icon = "ERROR", text="", icon_only = True, emboss = False)
+                                row.prop(obj, '["' + prop.prop_name + '"]', text="")
 
 class PANEL_PT_MustardUI_ExternalMorphs(MainPanel, bpy.types.Panel):
     bl_idname = "PANEL_PT_MustardUI_ExternalMorphs"
@@ -6665,8 +6612,6 @@ class PANEL_PT_MustardUI_Outfits(MainPanel, bpy.types.Panel):
                 row2.label(text=prop.name)
             if prop.is_bool and prop.is_animatable:
                 row2.prop(prop, 'bool_value', text="")
-            elif prop.subtype == "COLOR" and prop.is_animatable:
-                row2.prop(prop, 'color_value', text="")
             elif not prop.is_animatable:
                 row2.prop(eval(prop.rna), prop.path, text="")
             else:

--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -12,7 +12,7 @@ bl_info = {
     "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "003"
+mustardui_buildnum = "004"
 
 import bpy
 import addon_utils
@@ -5819,7 +5819,8 @@ class MustardUI_Debug_Log(bpy.types.Operator):
         
         # Write to file
         try:
-            log_file = open('mustardui_log.txt','w')
+            abs_path = bpy.context.blend_data.filepath[:bpy.context.blend_data.filepath.rfind('\\')] + '\\'
+            log_file = open(abs_path+'mustardui_log.txt','w')
             log_file.write(log)
             log_file.close()
             

--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -12,7 +12,7 @@ bl_info = {
     "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "011"
+mustardui_buildnum = "012"
 
 import bpy
 import addon_utils
@@ -193,6 +193,8 @@ class MustardUI_Settings(bpy.types.PropertyGroup):
     # Property for custom properties errors
     custom_properties_error: bpy.props.BoolProperty(name = "",
                         description = "Can not find the property.\nCheck the property or use the Re-build Custom Properties operator in Settings")
+    custom_properties_error_nonanimatable: bpy.props.BoolProperty(name = "",
+                        description = "Can not find the property.\nRemove the property in the Configuration panel and add it again")
     
     # Property for morphs errors
     daz_morphs_error: bpy.props.BoolProperty(name = "",
@@ -2110,7 +2112,13 @@ class MUSTARDUI_UL_Property_UIList(bpy.types.UIList):
                     row.label(text="", icon="BLANK1")
                 
                 try:
-                    obj.id_properties_ui(item.prop_name)
+                    if item.is_animatable:
+                        obj.id_properties_ui(item.prop_name)
+                    else:
+                        if "[" in item.path and "]" in item.path:
+                            eval(item.rna+item.path)
+                        else:
+                            eval(item.rna+'.'+item.path)
                     row.label(text="", icon="BLANK1")
                 except:
                     row.label(text="", icon="ERROR")
@@ -2164,7 +2172,13 @@ class MUSTARDUI_UL_Property_UIListOutfits(bpy.types.UIList):
                     row.label(text="", icon="BLANK1")
                 
                 try:
-                    obj.id_properties_ui(item.prop_name)
+                    if item.is_animatable:
+                        obj.id_properties_ui(item.prop_name)
+                    else:
+                        if "[" in item.path and "]" in item.path:
+                            eval(item.rna+item.path)
+                        else:
+                            eval(item.rna+'.'+item.path)
                     row.label(text="", icon="BLANK1")
                 except:
                     row.label(text="", icon="ERROR")
@@ -2208,7 +2222,13 @@ class MUSTARDUI_UL_Property_UIListHair(bpy.types.UIList):
                     row.label(text="", icon="BLANK1")
                 
                 try:
-                    obj.id_properties_ui(item.prop_name)
+                    if item.is_animatable:
+                        obj.id_properties_ui(item.prop_name)
+                    else:
+                        if "[" in item.path and "]" in item.path:
+                            eval(item.rna+item.path)
+                        else:
+                            eval(item.rna+'.'+item.path)
                     row.label(text="", icon="BLANK1")
                 except:
                     row.label(text="", icon="ERROR")
@@ -6474,7 +6494,10 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
                     if prop.is_bool and prop.is_animatable:
                         row.prop(prop, 'bool_value', text="")
                     elif not prop.is_animatable:
-                        row.prop(eval(prop.rna), prop.path, text="")
+                        try:
+                            row.prop(eval(prop.rna), prop.path, text="")
+                        except:
+                            row.prop(settings, 'custom_properties_error_nonanimatable', icon = "ERROR", text="", icon_only = True, emboss = False)
                     else:
                         if prop.prop_name in obj.keys():
                             row.prop(obj, '["' + prop.prop_name + '"]', text="")
@@ -6506,7 +6529,10 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
                             if prop.is_bool and prop.is_animatable:
                                 row.prop(prop, 'bool_value', text="")
                             elif not prop.is_animatable:
-                                row.prop(eval(prop.rna), prop.path, text="")
+                                try:
+                                    row.prop(eval(prop.rna), prop.path, text="")
+                                except:
+                                    row.prop(settings, 'custom_properties_error_nonanimatable', icon = "ERROR", text="", icon_only = True, emboss = False)
                             else:
                                 if prop.prop_name in obj.keys():
                                     row.prop(obj, '["' + prop.prop_name + '"]', text="")
@@ -6689,7 +6715,10 @@ class PANEL_PT_MustardUI_Outfits(MainPanel, bpy.types.Panel):
             if prop.is_bool and prop.is_animatable:
                 row2.prop(prop, 'bool_value', text="")
             elif not prop.is_animatable:
-                row2.prop(eval(prop.rna), prop.path, text="")
+                try:
+                    row2.prop(eval(prop.rna), prop.path, text="")
+                except:
+                    row2.prop(settings, 'custom_properties_error_nonanimatable', icon = "ERROR", text="", icon_only = True, emboss = False)
             else:
                 if prop.prop_name in arm.keys():
                     row2.prop(arm, '["' + prop.prop_name + '"]', text="")

--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -12,7 +12,7 @@ bl_info = {
     "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "012"
+mustardui_buildnum = "013"
 
 import bpy
 import addon_utils
@@ -372,27 +372,6 @@ class MustardUI_RigSettings(bpy.types.PropertyGroup):
                 obj.data.use_auto_smooth = False
         
         return
-    
-    # Update function for Subsurface Scattering in materials
-    def update_sss(self, context):
-        
-        for mat in self.model_body.data.materials:
-            for node in mat.node_tree.nodes:
-                if node.name=='Subsurface':
-                    node.outputs[0].default_value = self.body_sss
-        return
-    
-    # Subsurface scattering
-    body_enable_sss: bpy.props.BoolProperty(default = True,
-                        name = "Subsurface Scattering",
-                        description = "")
-    
-    body_sss: bpy.props.FloatProperty(default = 0.02,
-                        min = 0.0,
-                        max = 1.0,
-                        name = "Subsurface Scattering",
-                        description = "Set the subsurface scattering intensity.\nThis effect will allow some light rays to go through the body skin. Be sure to set a correct value. If you are not sure, restore to the default value",
-                        update = update_sss)
     
     # Subdivision surface
     body_subdiv_rend: bpy.props.BoolProperty(default = True,
@@ -5976,7 +5955,6 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
         if not rig_settings.body_config_collapse:
             box = layout.box()
             box.label(text="Global properties", icon="MODIFIER")
-            box.prop(rig_settings,"body_enable_sss")
             box.prop(rig_settings,"body_enable_subdiv")
             box.prop(rig_settings,"body_enable_smoothcorr")
             box.prop(rig_settings,"body_enable_norm_autosmooth")
@@ -6435,7 +6413,7 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
             rig_settings = arm.MustardUI_RigSettings
             
             # Check if there is any property to show
-            prop_to_show = rig_settings.body_enable_sss or rig_settings.body_enable_subdiv or rig_settings.body_enable_smoothcorr or rig_settings.body_enable_norm_autosmooth
+            prop_to_show = rig_settings.body_enable_subdiv or rig_settings.body_enable_smoothcorr or rig_settings.body_enable_norm_autosmooth
         
             return res and prop_to_show
         
@@ -6452,7 +6430,7 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
         
         layout = self.layout
         
-        if rig_settings.body_enable_sss or rig_settings.body_enable_subdiv or rig_settings.body_enable_smoothcorr or rig_settings.body_enable_norm_autosmooth:
+        if rig_settings.body_enable_subdiv or rig_settings.body_enable_smoothcorr or rig_settings.body_enable_norm_autosmooth:
             
             box = layout.box()
             box.label(text="Body properties", icon="OUTLINER_OB_ARMATURE")
@@ -6473,9 +6451,6 @@ class PANEL_PT_MustardUI_Body(MainPanel, bpy.types.Panel):
             
             if rig_settings.body_enable_norm_autosmooth:
                 box.prop(rig_settings,"body_norm_autosmooth")
-            
-            if rig_settings.body_enable_sss:
-                box.prop(rig_settings,"body_sss")
             
             box.prop(settings,"material_normal_nodes")
         

--- a/mustard_ui.py
+++ b/mustard_ui.py
@@ -12,7 +12,7 @@ bl_info = {
     "doc_url": "https://github.com/Mustard2/MustardUI",
     "category": "User Interface",
 }
-mustardui_buildnum = "009"
+mustardui_buildnum = "011"
 
 import bpy
 import addon_utils
@@ -1752,23 +1752,6 @@ class MustardUI_Property_MenuLink(bpy.types.Operator):
     parent_path: bpy.props.StringProperty()
     type: bpy.props.EnumProperty(default = "BODY",
                         items = (("BODY", "Body", ""), ("OUTFIT", "Outfit", ""), ("HAIR", "Hair", "")))
-                        
-    # Function to check over all custom properties
-    def mustardui_check_cp(obj, rna, path):
-        
-        for cp in obj.MustardUI_CustomProperties:
-            if cp.rna == rna and cp.path == path:
-                return False
-        
-        for cp in obj.MustardUI_CustomPropertiesOutfit:
-            if cp.rna == rna and cp.path == path:
-                return False
-        
-        for cp in obj.MustardUI_CustomPropertiesHair:
-            if cp.rna == rna and cp.path == path:
-                return False
-
-        return True
     
     @classmethod
     def poll(cls, context):
@@ -2067,7 +2050,10 @@ class MUSTARDUI_MT_Property_LinkMenu(bpy.types.Menu):
             layout.separator()
             layout.label(text = "Outfits", icon = "MOD_CLOTH")
         for prop in sorted(sorted(outfit_props, key = lambda x:x.name), key=lambda x:x.outfit.name):
-            outfit_name = prop.outfit.name[len(rig_settings.model_name):] if rig_settings.model_MustardUI_naming_convention else prop.outfit.name
+            outfit_name = prop.outfit.name[len(rig_settings.model_name + " "):] if rig_settings.model_MustardUI_naming_convention else prop.outfit.name
+            if prop.outfit_piece != None:
+                outfit_piece_name = prop.outfit_piece.name[len(prop.outfit.name + " - "):] if rig_settings.model_MustardUI_naming_convention else prop.outfit.name
+                outfit_name = outfit_name + " - " + outfit_piece_name
             op = layout.operator(MustardUI_Property_MenuLink.bl_idname, text=outfit_name + " - " + prop.name, icon=prop.icon)
             op.parent_rna = prop.rna
             op.parent_path = prop.path
@@ -2091,7 +2077,7 @@ class MUSTARDUI_MT_Property_LinkMenu(bpy.types.Menu):
             layout.separator()
             layout.label(text = "Hair", icon = "HAIR")
         for prop in sorted(hair_props, key = lambda x:x.name):
-            hair_name = prop.hair.name[len(rig_settings.hair_collection.name):] if rig_settings.model_MustardUI_naming_convention else prop.hair.name
+            hair_name = prop.hair.name[len(rig_settings.hair_collection.name + " "):] if rig_settings.model_MustardUI_naming_convention else prop.hair.name
             op = layout.operator(MustardUI_Property_MenuLink.bl_idname, text=hair_name + " - " + prop.name, icon=prop.icon)
             op.parent_rna = prop.rna
             op.parent_path = prop.path


### PR DESCRIPTION
- custom properties should now be fully Blender 3.0 compatible (it needed a complete rework due to the deprecation of RNA_UI)
- fixed colors not being able to set description is settings

Note: from version 0.22, Blender 3.0 will be compulsory. While for models based on 2.93, you will need to use 0.21.x or below.