### PR TITLE
Version 0.30.3

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 1),
+    "version": (0, 30, 3, 2),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 3),
+    "version": (0, 30, 3, 4),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 5),
+    "version": (0, 30, 3, 8),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 2, 15),
+    "version": (0, 30, 3, 1),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 2),
+    "version": (0, 30, 3, 3),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 8),
+    "version": (0, 30, 3, 10),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (0, 30, 3, 4),
+    "version": (0, 30, 3, 5),
     "blender": (4, 0, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/armature/ui_list.py
+++ b/armature/ui_list.py
@@ -14,22 +14,28 @@ class MUSTARDUI_UL_Armature_UIList(bpy.types.UIList):
         active_bone = armature.edit_bones.active or armature.bones.active
         has_active_bone = active_bone and bcoll.name in active_bone.collections
 
+        row = layout.row(align=True)
+
+        # Check if the icon should be drawn
+        for b in armature.collections:
+            if b.MustardUI_ArmatureBoneCollection.icon != "NONE":
+                row.label(text="", icon=bcoll_settings.icon if bcoll_settings.icon != "NONE" else "BLANK1")
+                break
+
         if settings.advanced:
-            layout.prop(bcoll, "name", text="", emboss=False,
+            row.prop(bcoll, "name", text="", emboss=False,
                         icon='DOT' if has_active_bone else 'BLANK1')
         else:
-            layout.prop(bcoll, "name", text="", emboss=False)
+            row.prop(bcoll, "name", text="", emboss=False)
 
         if armature.override_library:
             icon = 'LIBRARY_DATA_OVERRIDE' if bcoll.is_local_override else 'BLANK1'
-            layout.prop(
+            row.prop(
                 bcoll,
                 "is_local_override",
                 text="",
                 emboss=False,
                 icon=icon)
-
-        row = layout.row(align=True)
 
         row.label(text="", icon="EXPERIMENTAL" if bcoll_settings.advanced else "BLANK1")
         row.label(text="", icon="MOD_CLOTH" if bcoll_settings.outfit_switcher_enable else "BLANK1")

--- a/custom_properties/ui_list.py
+++ b/custom_properties/ui_list.py
@@ -136,7 +136,7 @@ class MUSTARDUI_UL_Property_UIListHair(bpy.types.UIList):
                 if rig_settings.model_MustardUI_naming_convention:
                     row.label(text=item.hair.name[len(rig_settings.model_name) + 1:])
                 else:
-                    row.label(text=item.outfit.name)
+                    row.label(text=item.hair.name)
 
             if addon_prefs.debug:
                 if item.is_animatable:

--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -386,9 +386,12 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
                 row.enabled = not bcoll_settings.outfit_switcher_enable
                 row.prop(bcoll_settings, 'advanced')
 
-                # Disabled for now due to Blender bug https://projects.blender.org/blender/blender/issues/116061
+                # Warning for Blender bug https://projects.blender.org/blender/blender/issues/116061
                 col = box.column(align=True)
-                col.enabled = False
+                row = col.row(align=True)
+                row.label(text="The feature below might cause", icon="ERROR")
+                row.operator("mustardui.openlink", icon="URL", text="").url = "https://projects.blender.org/blender/blender/issues/116061"
+                col.label(text="crashes due to a Blender bug!", icon="BLANK1")
                 col.prop(bcoll_settings, 'outfit_switcher_enable')
                 if bcoll_settings.outfit_switcher_enable:
                     col.prop(bcoll_settings, 'outfit_switcher_collection', text="Collection")

--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -386,6 +386,9 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
                 row.enabled = not bcoll_settings.outfit_switcher_enable
                 row.prop(bcoll_settings, 'advanced')
 
+                # Disabled for now due to Blender bug https://projects.blender.org/blender/blender/issues/116061
+                col = box.column(align=True)
+                col.enabled = False
                 col.prop(bcoll_settings, 'outfit_switcher_enable')
                 if bcoll_settings.outfit_switcher_enable:
                     col.prop(bcoll_settings, 'outfit_switcher_collection', text="Collection")

--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -387,16 +387,17 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
                 row.prop(bcoll_settings, 'advanced')
 
                 # Warning for Blender bug https://projects.blender.org/blender/blender/issues/116061
-                col = box.column(align=True)
-                row = col.row(align=True)
-                row.label(text="The feature below might cause", icon="ERROR")
-                row.operator("mustardui.openlink", icon="URL", text="").url = "https://projects.blender.org/blender/blender/issues/116061"
-                col.label(text="crashes due to a Blender bug!", icon="BLANK1")
-                col.prop(bcoll_settings, 'outfit_switcher_enable')
-                if bcoll_settings.outfit_switcher_enable:
-                    col.prop(bcoll_settings, 'outfit_switcher_collection', text="Collection")
-                    if bcoll_settings.outfit_switcher_collection is not None:
-                        col.prop(bcoll_settings, 'outfit_switcher_object', text="Object")
+                if addon_prefs.experimental:
+                    col = box.column(align=True)
+                    row = col.row(align=True)
+                    row.label(text="The feature below might cause", icon="ERROR")
+                    row.operator("mustardui.openlink", icon="URL", text="").url = "https://projects.blender.org/blender/blender/issues/116061"
+                    col.label(text="crashes due to a Blender bug!", icon="BLANK1")
+                    col.prop(bcoll_settings, 'outfit_switcher_enable')
+                    if bcoll_settings.outfit_switcher_enable:
+                        col.prop(bcoll_settings, 'outfit_switcher_collection', text="Collection")
+                        if bcoll_settings.outfit_switcher_collection is not None:
+                            col.prop(bcoll_settings, 'outfit_switcher_object', text="Object")
 
         # Physics Settings
         row = layout.row(align=False)

--- a/menu/menu_morphs.py
+++ b/menu/menu_morphs.py
@@ -23,20 +23,20 @@ class PANEL_PT_MustardUI_ExternalMorphs(MainPanel, bpy.types.Panel):
     @classmethod
     def poll(cls, context):
 
-        settings = bpy.context.scene.MustardUI_Settings
-
         res, arm = mustardui_active_object(context, config=0)
 
         if arm is not None:
             rig_settings = arm.MustardUI_RigSettings
 
             # Check if at least one panel is available
-            panels = rig_settings.diffeomorphic_emotions or rig_settings.diffeomorphic_emotions_units or rig_settings.diffeomorphic_facs_emotions_units or rig_settings.diffeomorphic_facs_emotions or rig_settings.diffeomorphic_body_morphs
+            panels = (rig_settings.diffeomorphic_emotions or rig_settings.diffeomorphic_emotions_units or
+                      rig_settings.diffeomorphic_facs_emotions_units or rig_settings.diffeomorphic_facs_emotions or
+                      rig_settings.diffeomorphic_body_morphs)
 
-            return res and rig_settings.diffeomorphic_support and panels and rig_settings.diffeomorphic_morphs_number > 0
+            return (res and rig_settings.diffeomorphic_support and panels and
+                    rig_settings.diffeomorphic_morphs_number > 0)
 
-        else:
-            return res
+        return res
 
     def draw_header(self, context):
 
@@ -60,7 +60,7 @@ class PANEL_PT_MustardUI_ExternalMorphs(MainPanel, bpy.types.Panel):
 
         # Check Diffeomorphic version and inform the user about possible issues
         if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
-            settings.status_diffeomorphic_version[2]) <= (1, 6, 0):
+            settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
             box = layout.box()
             box.label(icon='ERROR', text="Diffeomorphic version not supported!")
             box.label(icon='BLANK1', text="Only 1.6 or above is supported.")

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -59,7 +59,7 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(text="Diffeomorphic:   " + str(settings.status_diffeomorphic_version[0]) + '.' + str(
                         settings.status_diffeomorphic_version[1]) + '.' + str(settings.status_diffeomorphic_version[2]))
 
-        if addon_prefs.debug and (addon_prefs(rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0) or (
+        if addon_prefs.debug and ((rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0) or (
                 rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 1) or (
                 settings.status_diffeomorphic == 0 and rig_settings.diffeomorphic_support) or (
                 settings.status_diffeomorphic == 1 and rig_settings.diffeomorphic_support) or (

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -49,7 +49,7 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
             if platform.system() == 'Windows':
                 box.operator('wm.console_toggle', text="Toggle System Console", icon="CONSOLE")
 
-        if rig_settings.model_version != '' or (addon_prefs.debug and rig_settings.diffeomorphic_support):
+        if rig_settings.model_version != '' or (addon_prefs.debug and rig_settings.diffeomorphic_support and settings.status_diffeomorphic_version[0] > 0):
             box = layout.box()
             box.label(text="Version", icon="INFO")
             if rig_settings.model_version != '':
@@ -79,8 +79,11 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(icon='ERROR', text="Diffeomorphic not installed!")
 
                 if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
-                    settings.status_diffeomorphic_version[2]) <= (1, 6, 0):
+                    settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
                     box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
+                elif settings.status_diffeomorphic_version[0] == -1:
+                    box.label(icon='ERROR', text="Diffeomorphic version not found!")
+
 
 
 def register():

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -85,7 +85,6 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(icon='ERROR', text="Diffeomorphic version not found!")
 
 
-
 def register():
     bpy.utils.register_class(PANEL_PT_MustardUI_SettingsPanel)
 

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -59,11 +59,11 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(text="Diffeomorphic:   " + str(settings.status_diffeomorphic_version[0]) + '.' + str(
                         settings.status_diffeomorphic_version[1]) + '.' + str(settings.status_diffeomorphic_version[2]))
 
-        if (rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0) or (
+        if addon_prefs.debug and (addon_prefs(rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0) or (
                 rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 1) or (
                 settings.status_diffeomorphic == 0 and rig_settings.diffeomorphic_support) or (
                 settings.status_diffeomorphic == 1 and rig_settings.diffeomorphic_support) or (
-                (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1], settings.status_diffeomorphic_version[2]) <= (1, 6, 0)):
+                (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1], settings.status_diffeomorphic_version[2]) <= (1, 6, 0))):
             box = layout.box()
 
             if rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 1:
@@ -77,12 +77,12 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(icon='ERROR', text="Diffeomorphic not enabled!")
                 elif settings.status_diffeomorphic == 0:
                     box.label(icon='ERROR', text="Diffeomorphic not installed!")
-
-                if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
-                    settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
-                    box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
-                elif settings.status_diffeomorphic_version[0] == -1:
-                    box.label(icon='ERROR', text="Diffeomorphic version not found!")
+                else:
+                    if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
+                        settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
+                        box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
+                    elif settings.status_diffeomorphic_version[0] == -1:
+                        box.label(icon='ERROR', text="Diffeomorphic version not found!")
 
 
 def register():

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -71,14 +71,16 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
             elif rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0:
                 box.label(icon='ERROR', text="rig_tools not installed!")
 
-            if settings.status_diffeomorphic == 1 and rig_settings.diffeomorphic_support:
-                box.label(icon='ERROR', text="Diffeomorphic not enabled!")
-            elif settings.status_diffeomorphic == 0 and rig_settings.diffeomorphic_support:
-                box.label(icon='ERROR', text="Diffeomorphic not installed!")
+            if rig_settings.diffeomorphic_support:
 
-            if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
-                settings.status_diffeomorphic_version[2]) <= (1, 6, 0):
-                box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
+                if settings.status_diffeomorphic == 1:
+                    box.label(icon='ERROR', text="Diffeomorphic not enabled!")
+                elif settings.status_diffeomorphic == 0:
+                    box.label(icon='ERROR', text="Diffeomorphic not installed!")
+
+                if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
+                    settings.status_diffeomorphic_version[2]) <= (1, 6, 0):
+                    box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
 
 
 def register():

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -59,31 +59,6 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
                     box.label(text="Diffeomorphic:   " + str(settings.status_diffeomorphic_version[0]) + '.' + str(
                         settings.status_diffeomorphic_version[1]) + '.' + str(settings.status_diffeomorphic_version[2]))
 
-        if addon_prefs.debug and ((rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0) or (
-                rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 1) or (
-                settings.status_diffeomorphic == 0 and rig_settings.diffeomorphic_support) or (
-                settings.status_diffeomorphic == 1 and rig_settings.diffeomorphic_support) or (
-                (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1], settings.status_diffeomorphic_version[2]) <= (1, 6, 0))):
-            box = layout.box()
-
-            if rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 1:
-                box.label(icon='ERROR', text="rig_tools not enabled!")
-            elif rig_settings.model_rig_type == "arp" and settings.status_rig_tools == 0:
-                box.label(icon='ERROR', text="rig_tools not installed!")
-
-            if rig_settings.diffeomorphic_support:
-
-                if settings.status_diffeomorphic == 1:
-                    box.label(icon='ERROR', text="Diffeomorphic not enabled!")
-                elif settings.status_diffeomorphic == 0:
-                    box.label(icon='ERROR', text="Diffeomorphic not installed!")
-                else:
-                    if (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
-                        settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
-                        box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
-                    elif settings.status_diffeomorphic_version[0] == -1:
-                        box.label(icon='ERROR', text="Diffeomorphic version not found!")
-
 
 def register():
     bpy.utils.register_class(PANEL_PT_MustardUI_SettingsPanel)

--- a/menu/menu_warnings.py
+++ b/menu/menu_warnings.py
@@ -1,5 +1,6 @@
 import bpy
 from . import MainPanel
+from ..model_selection.active_object import *
 from ..warnings.ops_fix_old_UI import check_old_UI
 from ..warnings.ops_fix_eevee_normals import check_eevee_normals
 
@@ -11,9 +12,18 @@ class PANEL_PT_MustardUI_Warnings(MainPanel, bpy.types.Panel):
 
     @classmethod
     def poll(cls, context):
-        # Check presence of old UI scripts
+
         settings = bpy.context.scene.MustardUI_Settings
-        return check_old_UI() or check_eevee_normals(context.scene, settings)
+        poll, obj = mustardui_active_object(context, config=0)
+        rig_settings = obj.MustardUI_RigSettings
+
+        check_arp = rig_settings.model_rig_type == "arp" and settings.status_rig_tools != 2
+        check_diffeomorphic = (rig_settings.diffeomorphic_support and settings.status_diffeomorphic == 2 and
+                               (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
+                                settings.status_diffeomorphic_version[2]) <= (1, 6, 0)
+                               and settings.status_diffeomorphic_version[0] > -1)
+        check_mhx = rig_settings.diffeomorphic_support and settings.status_mhx != 2
+        return settings.mustardui_update_available or check_old_UI() or check_eevee_normals(context.scene, settings) or check_arp or check_diffeomorphic or check_mhx
 
     def draw_header(self, context):
         self.layout.label(text="", icon="ERROR")
@@ -21,8 +31,17 @@ class PANEL_PT_MustardUI_Warnings(MainPanel, bpy.types.Panel):
     def draw(self, context):
 
         settings = bpy.context.scene.MustardUI_Settings
+        poll, obj = mustardui_active_object(context, config=0)
+        rig_settings = obj.MustardUI_RigSettings
 
         layout = self.layout
+
+        # New MustardUI version available
+        if settings.mustardui_update_available:
+            box = layout.box()
+            col = box.column(align=True)
+            col.label(text="MustardUI update available!", icon="ERROR")
+            box.operator("mustardui.openlink", icon="URL").url = "github.com/Mustard2/MustardUI/releases/latest"
 
         # Old UI scripts
         if check_old_UI():
@@ -31,11 +50,42 @@ class PANEL_PT_MustardUI_Warnings(MainPanel, bpy.types.Panel):
             col.label(text="Old UI script found!", icon="ERROR")
             box.operator("mustardui.warnings_fix_old_ui")
 
+        # Eevee normals enabled in Cycles
         if check_eevee_normals(context.scene, settings):
             box = layout.box()
             col = box.column(align=True)
             col.label(text="Eevee Optimed Normals are active with Cycles!", icon="ERROR")
             box.operator("mustardui.warnings_fix_eevee_normals")
+
+        # ARP support without rig_tools installed
+        if rig_settings.model_rig_type == "arp":
+            if settings.status_rig_tools == 1:
+                box = layout.box()
+                col = box.column(align=True)
+                col.label(icon='ERROR', text="rig_tools not enabled!")
+            elif settings.status_rig_tools == 0:
+                box = layout.box()
+                col = box.column(align=True)
+                col.label(icon='ERROR', text="rig_tools not installed!")
+
+        # Diffeomorphic support checks on versions
+        if rig_settings.diffeomorphic_support and settings.status_diffeomorphic == 2 and  (settings.status_diffeomorphic_version[0], settings.status_diffeomorphic_version[1],
+            settings.status_diffeomorphic_version[2]) <= (1, 6, 0) and settings.status_diffeomorphic_version[0] > -1:
+            box = layout.box()
+            box.label(icon='ERROR', text="Diffeomorphic 1.5 or below are not supported!")
+            box.operator("mustardui.openlink", text="Update Diffeomorphic", icon="URL").url = "https://bitbucket.org/Diffeomorphic/import_daz/wiki/Home"
+
+        # MHX Runtime
+        if rig_settings.diffeomorphic_support and settings.status_mhx != 2:
+            if settings.status_mhx == 1:
+                box = layout.box()
+                col = box.column(align=True)
+                col.label(icon='ERROR', text="MHX runtime not enabled!")
+            elif settings.status_mhx == 0:
+                box = layout.box()
+                col = box.column(align=True)
+                col.label(icon='ERROR', text="MHX runtime not installed!")
+                box.operator("mustardui.openlink", text="Install MHX", icon="URL").url = "https://bitbucket.org/Diffeomorphic/mhx_rts/wiki/Home"
 
 
 def register():

--- a/misc/ops_fix_missing_UI.py
+++ b/misc/ops_fix_missing_UI.py
@@ -6,7 +6,7 @@ from .. import bl_info
 class MustardUI_FixMissingUI(bpy.types.Operator):
     """Fix Missing UI in case Viewport Model selection was off and the Armature selection has been corrupted"""
     bl_idname = "mustardui.fix_missing_ui"
-    bl_label = "Try fix Missing UI"
+    bl_label = "Fix Missing UI"
     bl_options = {'UNDO'}
 
     @classmethod

--- a/misc/updater.py
+++ b/misc/updater.py
@@ -3,6 +3,47 @@ from bpy.props import *
 from .. import bl_info
 
 
+def mustardui_retrieve_remote_version():
+
+    import requests
+
+    v = [0, 0, 0, 0]
+    data = None
+
+    # Import the data from the GitHub repository file
+    try:
+        response = requests.get("https://raw.githubusercontent.com/Mustard2/MustardUI/master/__init__.py")
+        data = response.text
+    except:
+        return 1, v
+
+    # Fetch version
+    try:
+        if '"version": (' in data:
+            find = data.split('"version": (', 1)[1]
+            v[0] = int(find.split(',')[0])
+            v[1] = int(find.split(',')[1])
+            v[2] = int(find.split(',')[2])
+            v[3] = find.split(',')[3]
+            v[3] = int(v[3].split(')')[0])
+
+            return 0, v
+    except:
+        pass
+
+    return 2, v
+
+
+def mustardui_check_version():
+    exit_code, v = mustardui_retrieve_remote_version()
+    version = (v[0], v[1], v[2])
+    if bl_info["version"] < version:
+        print("MustardUI - An update is available.")
+    else:
+        print("MustardUI - No update available.")
+    return bl_info["version"] < version
+
+
 class MustardUI_Updater(bpy.types.Operator):
     """Check MustardUI version"""
     bl_idname = "mustardui.updater"
@@ -10,9 +51,6 @@ class MustardUI_Updater(bpy.types.Operator):
     bl_options = {'UNDO'}
 
     v = [0, 0, 0, 0]
-
-    def __init__(self):
-        self.data = None
 
     @classmethod
     def poll(cls, context):
@@ -31,25 +69,13 @@ class MustardUI_Updater(bpy.types.Operator):
 
     def invoke(self, context, event):
 
-        import requests
+        exit_code, self.v = mustardui_retrieve_remote_version()
 
-        # Import the data from the GitHub repository file
-        try:
-            response = requests.get("https://raw.githubusercontent.com/Mustard2/MustardUI/master/__init__.py")
-            self.data = response.text
-        except:
+        if exit_code == 1:
             self.report({'ERROR'}, "MustardUI: Error while retrieving remote version. Check your connection")
             return {'FINISHED'}
 
-        # Fetch version
-        if '"version": (' in self.data:
-            find = self.data.split('"version": (', 1)[1]
-            self.v[0] = int(find.split(',')[0])
-            self.v[1] = int(find.split(',')[1])
-            self.v[2] = int(find.split(',')[2])
-            self.v[3] = find.split(',')[3]
-            self.v[3] = int(self.v[3].split(')')[0])
-        else:
+        if exit_code == 2:
             self.report({'ERROR'}, "MustardUI: Can not find the version number of the remote repository")
             return {'FINISHED'}
 

--- a/settings/addon.py
+++ b/settings/addon.py
@@ -87,7 +87,6 @@ class MustardUI_Settings(bpy.types.PropertyGroup):
 
             an = ""
             for addon in addon_utils.addons_fake_modules:
-                print(addon_name + "   " + addon)
                 if addon_name in addon:
                     default, state = addon_utils.check(addon)
                     if default:

--- a/settings/addon.py
+++ b/settings/addon.py
@@ -97,7 +97,7 @@ class MustardUI_Settings(bpy.types.PropertyGroup):
                 print("MustardUI - Can not find " + addon_name + " version.")
                 return (-1, -1, -1)
 
-            mod = sys.modules[an]
+            mod = addon_utils.addons_fake_modules[an]
             version = mod.bl_info.get('version', (-1, -1, -1))
             print("MustardUI - " + an + " version is " + str(version[0]) + "." + str(version[1]) + "." + str(
                 version[2]) + ".")

--- a/settings/addon.py
+++ b/settings/addon.py
@@ -85,15 +85,22 @@ class MustardUI_Settings(bpy.types.PropertyGroup):
             # Find the correct addon name
             addon_utils.modules_refresh()
 
+            an = ""
             for addon in addon_utils.addons_fake_modules:
+                print(addon_name + "   " + addon)
                 if addon_name in addon:
                     default, state = addon_utils.check(addon)
-                    if state:
+                    if default:
+                        an = addon
                         break
 
-            mod = sys.modules[addon]
+            if an == "":
+                print("MustardUI - Can not find " + addon_name + " version.")
+                return (-1, -1, -1)
+
+            mod = sys.modules[an]
             version = mod.bl_info.get('version', (-1, -1, -1))
-            print("MustardUI - " + addon + " version is " + str(version[0]) + "." + str(version[1]) + "." + str(
+            print("MustardUI - " + an + " version is " + str(version[0]) + "." + str(version[1]) + "." + str(
                 version[2]) + ".")
             return (version[0], version[1], version[2])
         except:

--- a/settings/addon.py
+++ b/settings/addon.py
@@ -1,5 +1,6 @@
 import bpy
 from bpy.props import *
+from ..misc.updater import mustardui_check_version
 import addon_utils
 import sys
 
@@ -33,6 +34,9 @@ class MustardUI_Settings(bpy.types.PropertyGroup):
                                                                            "available on the scene")
 
     panel_model_selection_armature: PointerProperty(type=bpy.types.Armature)
+
+    # MustardUI version check
+    mustardui_update_available: BoolProperty(default=mustardui_check_version())
 
     # RIG TOOLS STATUS
 


### PR DESCRIPTION
- Feature #133 : Warning when an update is available
- Feature: Warning when MHX is not installed or enabled.
- Bug #137: Hair custom properties were not displayed correctly in configuration mode if MustardUI Naming Convention was disabled.
- Bug: Fixed some issues related to the Diffeomorphic support (thanks to @mokujinh). The add-on should now correctly find the Diffeomorphic version and not show version issues if the Diffeomorphic support is not requested
- Bug: Fixed an issue that prevented the morphs to be used in some models (Diffeomorphic version not supported error).
- Bug: Warning added on Outfits Switcher due to Blender bug (https://projects.blender.org/blender/blender/issues/116061). It will be reverted as soon as the bug is fixed.

Note: if you are using the Armature Outfit Switcher, please remove BOTH the outfit piece and the collection (in this order!), and disable it. Since this feature might causes crashes, I hidden it with the Experimental Features addon flag: thus enable it to remove this feature from your models! You can find this flag in the addon settings (Blender Settings -> search for MustardUI) similarly to the Developer and Debug modes.