### PR TITLE
Version 2025.3.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2025, 3, 0),
+    "version": (2025, 3, 1),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2025.3.0"
+version = "2025.3.1"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/configuration/ops_cleanmodel.py
+++ b/configuration/ops_cleanmodel.py
@@ -118,6 +118,16 @@ class MustardUI_CleanModel(bpy.types.Operator):
 
         return (string == string_cmp or check_eCTRL or check_eJCM) and check_pJCM and check_facs
 
+    def locked_outfits_collections(self, rig_settings):
+
+        locked_objects = set()
+        for coll in [x for x in rig_settings.outfits_collections if x.collection is not None]:
+            items = coll.collection.all_objects if rig_settings.outfit_config_subcollections else coll.collection.objects
+            for obj in items:
+                if obj.MustardUI_outfit_lock:
+                    locked_objects.add(coll)
+        return list(locked_objects)
+
     @classmethod
     def poll(cls, context):
         res, arm = mustardui_active_object(context, config=0)
@@ -356,7 +366,7 @@ class MustardUI_CleanModel(bpy.types.Operator):
 
             current_outfit = rig_settings.outfits_list
 
-            to_remove = [x.collection for x in [y for y in rig_settings.outfits_collections if y.collection is not None]
+            to_remove = [x.collection for x in [y for y in rig_settings.outfits_collections if y.collection is not None and y not in self.locked_outfits_collections(rig_settings)]
                          if x.collection.name != current_outfit]
 
             for col in to_remove:
@@ -443,6 +453,8 @@ class MustardUI_CleanModel(bpy.types.Operator):
             self.report({'WARNING'}, "MustardUI - No operation was needed with current cleaning settings.")
 
         return {'FINISHED'}
+
+
 
     def invoke(self, context, event):
         return context.window_manager.invoke_props_dialog(self, width=500)

--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -3,7 +3,7 @@ from . import MainPanel
 from ..model_selection.active_object import *
 from ..warnings.ops_fix_old_UI import check_old_UI
 from .. import __package__ as base_package
-from ..settings.presets import MustarUI_PT_Presets
+from ..settings.presets import MUI_PT_Presets
 
 
 row_scale = 1.2
@@ -25,7 +25,7 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
         return res and addon_prefs.developer
 
     def draw_header_preset(self, _context):
-        MustarUI_PT_Presets.draw_panel_header(self.layout)
+        MUI_PT_Presets.draw_panel_header(self.layout)
 
     def draw(self, context):
 

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -25,7 +25,7 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
 
             # Check if one of these should be shown in the UI
             hair_avail = len([x for x in rig_settings.hair_collection.objects if x.type == "MESH"]) > 0 if rig_settings.hair_collection is not None else False
-            particle_avail = len([x for x in rig_settings.model_body.modifiers if x.type == "PARTICLE_SYSTEM"]) > 0 and rig_settings.particle_systems_enable if rig_settings.model_body != None else False
+            particle_avail = len([x for x in rig_settings.model_body.modifiers if x.type == "PARTICLE_SYSTEM"]) > 0 and rig_settings.particle_systems_enable if rig_settings.model_body is not None else False
             curved_hair = len([x for x in rig_settings.hair_collection.objects if x.type == "CURVES"]) > 0 if rig_settings.hair_collection is not None else False
 
             return res if (hair_avail or particle_avail or curved_hair) else False

--- a/menu/menu_outfits.py
+++ b/menu/menu_outfits.py
@@ -117,7 +117,7 @@ class PANEL_PT_MustardUI_Outfits(MainPanel, bpy.types.Panel):
 
             # Locked objects list
             locked_objects = []
-            for coll in [x for x in rig_settings.outfits_collections if x.collection != None]:
+            for coll in [x for x in rig_settings.outfits_collections if x.collection is not None]:
                 items = coll.collection.all_objects if rig_settings.outfit_config_subcollections else coll.collection.objects
                 for obj in items:
                     if obj.MustardUI_outfit_lock:

--- a/menu/menu_physics.py
+++ b/menu/menu_physics.py
@@ -198,13 +198,14 @@ class PANEL_PT_MustardUI_Physics_Items(MainPanel, bpy.types.Panel):
             row.prop(pi, 'enable', text="", icon="PHYSICS")
             row.prop(pi.object, 'hide_viewport', text="")
 
-            row = row.row()
-            row.enabled = False
-            items = [x for x in physics_settings.items if x.object]
-            for on in [x.object.name for x in items if x.object != pi.object]:
-                if check_mirror(pi.object.name, on, left=True) or check_mirror(pi.object.name, on, left=False):
-                    row.enabled = True
-            row.operator("mustardui.physics_mirror", text="", icon="MOD_MIRROR").obj_name = pi.object.name
+            if pi.type in ["CAGE", "SINGLE_ITEM"]:
+                row = row.row()
+                row.enabled = False
+                items = [x for x in physics_settings.items if x.object]
+                for on in [x.object.name for x in items if x.object != pi.object]:
+                    if check_mirror(pi.object.name, on, left=True) or check_mirror(pi.object.name, on, left=False):
+                        row.enabled = True
+                row.operator("mustardui.physics_mirror", text="", icon="MOD_MIRROR").obj_name = pi.object.name
 
             if pi.type == "BONES_DRIVER":
                 row = layout.row()

--- a/menu/menu_physics.py
+++ b/menu/menu_physics.py
@@ -194,7 +194,7 @@ class PANEL_PT_MustardUI_Physics_Items(MainPanel, bpy.types.Panel):
         row.prop(physics_settings, 'items_ui_list', text="")
 
         pi = physics_settings.items[int(physics_settings.items_ui_list)]
-        if pi.object and pi.type in ["CAGE", "COLLISION", "SINGLE_ITEM"]:
+        if pi.object and pi.type in ["CAGE", "COLLISION", "SINGLE_ITEM", "BONES_DRIVER"]:
             row.prop(pi, 'enable', text="", icon="PHYSICS")
             row.prop(pi.object, 'hide_viewport', text="")
 
@@ -205,6 +205,13 @@ class PANEL_PT_MustardUI_Physics_Items(MainPanel, bpy.types.Panel):
                 if check_mirror(pi.object.name, on, left=True) or check_mirror(pi.object.name, on, left=False):
                     row.enabled = True
             row.operator("mustardui.physics_mirror", text="", icon="MOD_MIRROR").obj_name = pi.object.name
+
+            if pi.type == "BONES_DRIVER":
+                row = layout.row()
+                row.prop(pi, 'bone_influence')
+            elif pi.type == "CAGE":
+                row = layout.row()
+                row.prop(pi, 'cage_influence')
 
             if pi.type in ["CAGE", "SINGLE_ITEM"]:
                 for mod in pi.object.modifiers:

--- a/menu/menu_tools_creators.py
+++ b/menu/menu_tools_creators.py
@@ -46,9 +46,9 @@ class PANEL_PT_MustardUI_ToolsCreators_Physics(MainPanel, bpy.types.Panel):
 
         row = layout.row(align=True)
         row.operator('mustardui.tools_creators_create_jiggle', text="Add Jiggle Cage", icon="OUTLINER_OB_FORCE_FIELD")
-        row.operator('mustardui.tools_creators_bone_physics_clean', text="", icon="X")
         row = layout.row(align=True)
         row.operator('mustardui.tools_creators_bone_physics', text="Add Bone Physics", icon="BONE_DATA")
+        row.operator('mustardui.tools_creators_bone_physics_clean', text="", icon="X")
         row = layout.row(align=True)
         row.operator('mustardui.tools_creators_hair_cage', text="Create Hair Cage", icon="OUTLINER_OB_CURVES")
         row.operator('mustardui.tools_creators_add_cloth_to_hair', text="", icon="MOD_CLOTH")

--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -61,7 +61,7 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
         # Enable/disable armature layers
         if armature_settings.outfits:
             collections = arm.collections_all
-            outfit_armature_layers = [x for x in collections if x.MustardUI_ArmatureBoneCollection.outfit_switcher_enable and x.MustardUI_ArmatureBoneCollection.outfit_switcher_collection != None]
+            outfit_armature_layers = [x for x in collections if x.MustardUI_ArmatureBoneCollection.outfit_switcher_enable and x.MustardUI_ArmatureBoneCollection.outfit_switcher_collection is not None]
             for bcoll in outfit_armature_layers:
                 bcoll_settings = bcoll.MustardUI_ArmatureBoneCollection
                 items = bcoll_settings.outfit_switcher_collection.all_objects if rig_settings.outfit_config_subcollections else bcoll_settings.outfit_switcher_collection.objects

--- a/physics/settings.py
+++ b/physics/settings.py
@@ -11,7 +11,7 @@ def items_list_make(self, context):
     for el in self.items:
         if el.object is None:
             continue
-        if hasattr(el.object, 'name') and el.type in ["CAGE", "COLLISION", "SINGLE_ITEM"]:
+        if hasattr(el.object, 'name') and el.type in ["CAGE", "COLLISION", "SINGLE_ITEM", "BONES_DRIVER"]:
             items.append((str(i), el.object.name, el.object.name, mustardui_physics_item_type_dict[el.type], i))
         i += 1
 

--- a/physics/settings_item.py
+++ b/physics/settings_item.py
@@ -1,6 +1,6 @@
 import bpy
 from ..model_selection.active_object import *
-from .update_enable import enable_physics_update_single, collisions_physics_update_single
+from .update_enable import *
 
 
 def poll_mesh(self, o):
@@ -20,12 +20,14 @@ def poll_mesh_linked(self, o):
 mustardui_physics_item_type = [("NONE", "None", "Disable Physics", "BLANK1", 0),
                                ("CAGE", "Cage", "A mesh that modifies another one through Mesh or Surface Deform modifiers", "MESH_UVSPHERE", 1),
                                ("COLLISION", "Collision", "A mesh that acts as collision for other meshes", "MOD_PHYSICS", 2),
-                               ("SINGLE_ITEM", "Single Item", "An item that does not need Mesh or Surface Deform modifiers on the Body or the Outfits", "OBJECT_ORIGIN", 3)]
+                               ("SINGLE_ITEM", "Single Item", "An item that does not need Mesh or Surface Deform modifiers on the Body or the Outfits", "OBJECT_ORIGIN", 3),
+                               ("BONES_DRIVER", "Bone Driver", "An item that drives the motion of bones through Constraints.\nOnly constraints with 'target' are supported", "BONE_DATA", 4)]
 mustardui_physics_item_type_dict = {
     "NONE": "BLANK1",
     "CAGE": "MESH_UVSPHERE",
     "COLLISION": "MOD_PHYSICS",
-    "SINGLE_ITEM": "OBJECT_ORIGIN"
+    "SINGLE_ITEM": "OBJECT_ORIGIN",
+    "BONES_DRIVER": "BONE_DATA"
 }
 
 
@@ -51,6 +53,18 @@ class MustardUI_PhysicsItem(bpy.types.PropertyGroup):
                                        name="Collisions",
                                        description="Enable/disable collisions on the modifiers",
                                        update=collisions_physics_update_single)
+
+    cage_influence: bpy.props.FloatProperty(default=1.0,
+                                            max=1.0, min=0.0,
+                                            name="Influence",
+                                            description="Influence of this Cage on other Objects",
+                                            update=cage_influence_update)
+
+    bone_influence: bpy.props.FloatProperty(default=1.0,
+                                            max=1.0, min=0.0,
+                                            name="Influence",
+                                            description="Influence of this item on bones constraints",
+                                            update=bone_influence_update)
 
     # UI Collapse
 

--- a/physics/update_enable.py
+++ b/physics/update_enable.py
@@ -104,7 +104,4 @@ def collisions_physics_update_single(self, context):
         if modifier.type in ['CLOTH']:
             modifier.collision_settings.use_collision = status
 
-    if not status:
-        self.object.hide_viewport = True
-
     return

--- a/settings/addon_prefs.py
+++ b/settings/addon_prefs.py
@@ -42,10 +42,10 @@ class MustardUI_AddonPrefs(bpy.types.AddonPreferences):
         row = col.row()
         row.enabled = self.developer
         row.prop(self, "debug")
-        col.separator()
-        row2 = col.row()
-        row2.enabled = False
-        row2.prop(self, "experimental")
+        # col.separator()
+        # row2 = col.row()
+        # row2.enabled = False
+        # row2.prop(self, "experimental")
 
         if self.debug:
             box = layout.box()

--- a/settings/presets.py
+++ b/settings/presets.py
@@ -4,14 +4,14 @@ from bl_ui.utils import PresetPanel
 from ..model_selection.active_object import *
 
 
-class MustarUI_PT_Presets(PresetPanel, bpy.types.Panel):
+class MUI_PT_Presets(PresetPanel, bpy.types.Panel):
     bl_label = 'MustardUI Presets'
     preset_subdir = 'mustardui/configuration'
     preset_operator = 'script.execute_preset'
     preset_add_operator = 'mustardui.add_preset'
 
 
-class MustardUI_MT_Presets(bpy.types.Menu):
+class MUI_MT_Presets(bpy.types.Menu):
     bl_label = 'MustardUI Presets'
     preset_subdir = 'mustardui/configuration'
     preset_operator = 'script.execute_preset'
@@ -21,7 +21,7 @@ class MustardUI_MT_Presets(bpy.types.Menu):
 class MustardUI_OT_AddPreset(AddPresetBase, bpy.types.Operator):
     bl_idname = 'mustardui.add_preset'
     bl_label = 'Add MustardUI Preset'
-    preset_menu = 'MustardUI_MT_Presets'
+    preset_menu = 'MUI_MT_Presets'
 
     @property
     def preset_defines(self):
@@ -95,11 +95,11 @@ class MustardUI_OT_AddPreset(AddPresetBase, bpy.types.Operator):
 
 def register():
     bpy.utils.register_class(MustardUI_OT_AddPreset)
-    bpy.utils.register_class(MustardUI_MT_Presets)
-    bpy.utils.register_class(MustarUI_PT_Presets)
+    bpy.utils.register_class(MUI_MT_Presets)
+    bpy.utils.register_class(MUI_PT_Presets)
 
 
 def unregister():
-    bpy.utils.unregister_class(MustarUI_PT_Presets)
-    bpy.utils.unregister_class(MustardUI_MT_Presets)
+    bpy.utils.unregister_class(MUI_PT_Presets)
+    bpy.utils.unregister_class(MUI_MT_Presets)
     bpy.utils.unregister_class(MustardUI_OT_AddPreset)

--- a/tools_creators/ops_bone_physics.py
+++ b/tools_creators/ops_bone_physics.py
@@ -131,7 +131,7 @@ class MustardUI_ToolsCreators_BonePhysics(bpy.types.Operator):
 
             # Add Damped Track constraint to the bone
             constraint = bone.constraints.new(type='DAMPED_TRACK')
-            constraint.name = "MustardUI Bone Physics"
+            constraint.name = curve_obj.name
             constraint.target = curve_obj  # The curve object as the target
             constraint.track_axis = 'TRACK_Y'  # Track the Y axis (you can change this if needed)
 
@@ -149,7 +149,6 @@ class MustardUI_ToolsCreators_BonePhysics(bpy.types.Operator):
         # Configure cloth modifier
         cloth_modifier.settings.quality = 5
         cloth_modifier.settings.mass = 0.15
-        cloth_modifier.collision_settings.use_collision = True
         cloth_modifier.settings.tension_stiffness = 5.
         cloth_modifier.settings.compression_stiffness = 5.
         cloth_modifier.settings.shear_stiffness = 5.
@@ -158,6 +157,9 @@ class MustardUI_ToolsCreators_BonePhysics(bpy.types.Operator):
         cloth_modifier.settings.compression_damping = 0.05
         cloth_modifier.settings.shear_damping = 0.05
         cloth_modifier.settings.bending_damping = 0.05
+
+        cloth_modifier.collision_settings.use_collision = True
+        cloth_modifier.collision_settings.distance_min = 0.001
 
         # Add the object to the Physics Panel
         if self.add_to_panel:
@@ -234,7 +236,7 @@ class MustardUI_ToolsCreators_BonePhysics_Clean(bpy.types.Operator):
         # Loop through all pose bones and remove the specific Damped Track constraints
         for bone in armature.pose.bones:
             for constraint in bone.constraints:
-                if constraint.type == 'DAMPED_TRACK' and constraint.name == 'MustardUI Bone Physics':
+                if constraint.type == 'DAMPED_TRACK' and constraint.target == curve_obj:
                     bone.constraints.remove(constraint)
 
         # Remove the item from the list if available


### PR DESCRIPTION
- **Feature**: Influence for single items for Surface deform and Bone Constraints.
- **Bug**: Fixed some naming Warnings.
- **Bug**: Updating the collision status was hiding the viewport object.
- **Bug**: The button for bone physics cleanup was misplaced.
- **Bug**: Bone physics cleanup was cleaning all the constraints, instead of only for one bone chain.
- **Bug**: Bone physics collision distance was set uncorrectly (now it is 0.001).