### PR TITLE
fix classname typo

### DIFF
--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -3,7 +3,7 @@ from . import MainPanel
 from ..model_selection.active_object import *
 from ..warnings.ops_fix_old_UI import check_old_UI
 from .. import __package__ as base_package
-from ..settings.presets import MustarUI_PT_Presets
+from ..settings.presets import MustardUI_PT_Presets
 
 
 row_scale = 1.2
@@ -25,7 +25,7 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
         return res and addon_prefs.developer
 
     def draw_header_preset(self, _context):
-        MustarUI_PT_Presets.draw_panel_header(self.layout)
+        MustardUI_PT_Presets.draw_panel_header(self.layout)
 
     def draw(self, context):
 

--- a/settings/presets.py
+++ b/settings/presets.py
@@ -4,7 +4,7 @@ from bl_ui.utils import PresetPanel
 from ..model_selection.active_object import *
 
 
-class MustarUI_PT_Presets(PresetPanel, bpy.types.Panel):
+class MustardUI_PT_Presets(PresetPanel, bpy.types.Panel):
     bl_label = 'MustardUI Presets'
     preset_subdir = 'mustardui/configuration'
     preset_operator = 'script.execute_preset'
@@ -96,10 +96,10 @@ class MustardUI_OT_AddPreset(AddPresetBase, bpy.types.Operator):
 def register():
     bpy.utils.register_class(MustardUI_OT_AddPreset)
     bpy.utils.register_class(MustardUI_MT_Presets)
-    bpy.utils.register_class(MustarUI_PT_Presets)
+    bpy.utils.register_class(MustardUI_PT_Presets)
 
 
 def unregister():
-    bpy.utils.unregister_class(MustarUI_PT_Presets)
+    bpy.utils.unregister_class(MustardUI_PT_Presets)
     bpy.utils.unregister_class(MustardUI_MT_Presets)
     bpy.utils.unregister_class(MustardUI_OT_AddPreset)


### PR DESCRIPTION
rename MustarUI_MT_Presets -> MustardUI_MT_Presets
notice the missing 'd' before 'UI'