### PR TITLE
Version 2024.4.1

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2025, 4, 0),
+    "version": (2025, 4, 1),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/armature/ops_smartcheck.py
+++ b/armature/ops_smartcheck.py
@@ -87,7 +87,7 @@ class MustardUI_Armature_SmartCheck(bpy.types.Operator):
             preset_mustard_models = [("Head", "", "USER", True),
                                      ("Face", "", "USER", False),
                                      ("Spine 2", "Spine", "", True),
-                                     ("Spine", "Spine Advanced", "", True),
+                                     ("Spine", "Spine Advanced", "", False),
                                      ("IK Arm Left", "", "", True),
                                      ("IK Arm Right", "", "", True),
                                      ("FK Arm Left", "", "", False),

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2025.4.0"
+version = "2025.4.1"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/configuration/ops_configuration.py
+++ b/configuration/ops_configuration.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.props import *
 from ..model_selection.active_object import *
 from .. import __package__ as base_package
+from datetime import datetime
 
 
 class MustardUI_Configuration(bpy.types.Operator):
@@ -132,6 +133,13 @@ class MustardUI_Configuration(bpy.types.Operator):
                             print(
                                 'MustardUI - Configuration Warning - The hair_list property index seems to be '
                                 'corrupted. Try to remove the UI and re-add it')
+
+            # Setting the model version date if requested
+            if rig_settings.model_version_date_enable:
+                date = datetime.today().strftime('%d/%m/%Y')
+                rig_settings.model_version_date = date
+            else:
+                rig_settings.model_version_date = ""
 
             if warnings > 0:
                 if addon_prefs.debug:

--- a/menu/menu_configure.py
+++ b/menu/menu_configure.py
@@ -44,6 +44,8 @@ class PANEL_PT_MustardUI_InitPanel(MainPanel, bpy.types.Panel):
         box.prop(rig_settings, "model_name", text="Name")
         box.prop(rig_settings, "model_body", text="Body")
 
+        box.prop(rig_settings, "model_MustardUI_naming_convention")
+
 
 def register():
     bpy.utils.register_class(PANEL_PT_MustardUI_InitPanel)

--- a/menu/menu_configure_external.py
+++ b/menu/menu_configure_external.py
@@ -8,7 +8,7 @@ from ..morphs.misc import DazCheckVersion
 
 
 class PANEL_PT_MustardUI_InitPanel_External(MainPanel, bpy.types.Panel):
-    bl_label = "External Add-ons"
+    bl_label = "Morphs (Diffeomorphic)"
     bl_parent_id = "PANEL_PT_MustardUI_InitPanel"
     bl_options = {"DEFAULT_CLOSED"}
 
@@ -34,18 +34,13 @@ class PANEL_PT_MustardUI_InitPanel_External(MainPanel, bpy.types.Panel):
         addon_prefs = context.preferences.addons[base_package].preferences
 
         box = layout.box()
-        box.label(text="Enable Support", icon="MODIFIER")
+        box.label(text="General", icon="MODIFIER")
         row = box.row()
-        row.prop(rig_settings, "diffeomorphic_support")
+        row.prop(rig_settings, "diffeomorphic_support", text="Enable Morph Panel")
         if rig_settings.diffeomorphic_support:
-
             box = layout.box()
-
-            box.label(text="Diffeomorphic Settings", icon="OUTLINER_DATA_SURFACE")
-
-            box2 = box.box()
-            box2.label(text="Morphs", icon="SHAPEKEY_DATA")
-            col = box2.column()
+            box.label(text="Categories", icon="SHAPEKEY_DATA")
+            col = box.column()
             col.prop(rig_settings, "diffeomorphic_emotions_units")
             col.prop(rig_settings, "diffeomorphic_emotions")
             if rig_settings.diffeomorphic_emotions:
@@ -62,15 +57,15 @@ class PANEL_PT_MustardUI_InitPanel_External(MainPanel, bpy.types.Panel):
                 row.scale_x = row_scale
                 row.prop(rig_settings, "diffeomorphic_body_morphs_custom", text="")
 
-            box2.separator()
-            row = box2.row(align=True)
+            box.separator()
+            row = box.row(align=True)
             row.label(text="Disable Exceptions")
             row.scale_x = row_scale
             row.prop(rig_settings, "diffeomorphic_disable_exceptions", text="")
 
-            box = box.box()
-            box.label(text="  Current morphs number: " + str(rig_settings.diffeomorphic_morphs_number))
-            box.operator('mustardui.morphs_check')
+            box = layout.box()
+            box.label(text="Morphs added: " + str(rig_settings.diffeomorphic_morphs_number), icon="LINENUMBERS_ON")
+            box.operator('mustardui.morphs_check', text="Search and Add Morphs", icon="ADD")
 
             if addon_prefs.debug:
 

--- a/menu/menu_configure_others.py
+++ b/menu/menu_configure_others.py
@@ -6,7 +6,7 @@ from .. import __package__ as base_package
 
 
 class PANEL_PT_MustardUI_InitPanel_Others(MainPanel, bpy.types.Panel):
-    bl_label = "Version"
+    bl_label = "Version & Others"
     bl_parent_id = "PANEL_PT_MustardUI_InitPanel"
     bl_options = {"DEFAULT_CLOSED"}
 

--- a/menu/menu_configure_others.py
+++ b/menu/menu_configure_others.py
@@ -6,7 +6,7 @@ from .. import __package__ as base_package
 
 
 class PANEL_PT_MustardUI_InitPanel_Others(MainPanel, bpy.types.Panel):
-    bl_label = "Version & Others"
+    bl_label = "Version"
     bl_parent_id = "PANEL_PT_MustardUI_InitPanel"
     bl_options = {"DEFAULT_CLOSED"}
 
@@ -33,10 +33,7 @@ class PANEL_PT_MustardUI_InitPanel_Others(MainPanel, bpy.types.Panel):
         box = layout.box()
         box.label(text="Version", icon="INFO")
         box.prop(rig_settings, "model_version", text="")
-
-        box = layout.box()
-        box.label(text="Naming", icon="OUTLINER_DATA_FONT")
-        box.prop(rig_settings, "model_MustardUI_naming_convention")
+        box.prop(rig_settings, "model_version_date_enable")
 
 
 def register():

--- a/menu/menu_configure_outfit.py
+++ b/menu/menu_configure_outfit.py
@@ -36,6 +36,7 @@ class PANEL_PT_MustardUI_InitPanel_Outfit(MainPanel, bpy.types.Panel):
         box.label(text="General Settings", icon="MODIFIER")
         col = box.column(align=True)
         col.prop(rig_settings, "outfit_nude")
+        col.prop(rig_settings, "outfit_physics_support", text="Physics Support")
         col.prop(rig_settings, "outfit_config_subcollections")
         col.prop(rig_settings, "outfit_additional_options")
 

--- a/menu/menu_developement.py
+++ b/menu/menu_developement.py
@@ -32,6 +32,8 @@ class PANEL_PT_MustardUI_Developement(MainPanel, bpy.types.Panel):
         layout = self.layout
 
         layout.operator('mustardui.configuration', text="UI Configuration", icon="PREFERENCES")
+
+        layout.separator()
         layout.operator('mustardui.property_rebuild', icon="MOD_BUILD", text="Re-build Custom Properties")
         layout.operator('mustardui.cleanmodel', text="Clean model", icon="BRUSH_DATA")
         layout.operator('mustardui.remove', text="UI Removal", icon="X")

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -82,8 +82,8 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
                     else:
                         custom_properties_obj = [x for x in arm.MustardUI_CustomPropertiesHair if x.hair == obj]
                     if len(custom_properties_obj) > 0 and rig_settings.outfit_additional_options:
-                        row.prop(obj, "MustardUI_additional_options_show", toggle=True, icon="PREFERENCES")
-                        if obj.MustardUI_additional_options_show:
+                        row.prop(obj.MustardUI_OutfitSettings, "additional_options_show", toggle=True, icon="PREFERENCES")
+                        if obj.MustardUI_OutfitSettings.additional_options_show:
                             mustardui_custom_properties_print(arm, settings, custom_properties_obj, box,
                                                               rig_settings.hair_custom_properties_icons)
 

--- a/menu/menu_outfits.py
+++ b/menu/menu_outfits.py
@@ -2,6 +2,7 @@ import bpy
 from . import MainPanel
 from ..model_selection.active_object import *
 from ..misc.ui_collapse import ui_collapse_prop
+from ..misc.icons_list import get_icon_show_visibility
 from ..warnings.ops_fix_old_UI import check_old_UI
 from ..settings.rig import *
 from .misc import *
@@ -28,7 +29,7 @@ def draw_outfit_piece(layout, obj, arm, rig_settings, settings, otype=0, level=0
 
     collapse = False
     if obj.children:
-        collapse = not ui_collapse_prop(row, obj, 'MustardUI_outfit_collapse_children', "", icon="",
+        collapse = not ui_collapse_prop(row, obj.MustardUI_OutfitSettings, 'collapse_children', "", icon="",
                                         align=False, use_layout=True, emboss=True, invert_checkbox=True)
 
     if rig_settings.model_MustardUI_naming_convention:
@@ -44,6 +45,14 @@ def draw_outfit_piece(layout, obj, arm, rig_settings, settings, otype=0, level=0
     else:
         row.operator("mustardui.object_visibility", text=obj.name, icon='OUTLINER_OB_' + obj.type,
                      depress=not obj.hide_viewport).obj = obj.name
+
+    # Physics
+    if rig_settings.outfit_physics_support:
+        for m in obj.modifiers:
+            mtype = m.type
+            if mtype in ["CLOTH", "SOFT_BODY", "COLLISION"]:
+                row.prop(obj.MustardUI_OutfitSettings, 'physics', text="", icon="PHYSICS" if mtype != "COLLISION" else "MOD_PHYSICS")
+                break
 
     # Outfit custom properties
     co_coll = None
@@ -61,8 +70,9 @@ def draw_outfit_piece(layout, obj, arm, rig_settings, settings, otype=0, level=0
                                  (x.outfit == co_coll if otype != 1 else True) and x.outfit_piece == obj and not x.hidden]
 
     if len(custom_properties_obj) > 0 and rig_settings.outfit_additional_options:
-        row.prop(obj, "MustardUI_additional_options_show", toggle=True, icon="PREFERENCES")
-        if obj.MustardUI_additional_options_show:
+        row.prop(obj.MustardUI_OutfitSettings, "additional_options_show" if otype != 1 else "additional_options_show_lock", toggle=True, icon="PREFERENCES")
+        check_show = obj.MustardUI_OutfitSettings.additional_options_show if otype != 1 else obj.MustardUI_OutfitSettings.additional_options_show_lock
+        if check_show:
             row2 = col.row(align=True)
             for lvl in range(level):
                 row2.label(text="", icon="BLANK1")

--- a/menu/menu_outfits.py
+++ b/menu/menu_outfits.py
@@ -2,7 +2,6 @@ import bpy
 from . import MainPanel
 from ..model_selection.active_object import *
 from ..misc.ui_collapse import ui_collapse_prop
-from ..misc.icons_list import get_icon_show_visibility
 from ..warnings.ops_fix_old_UI import check_old_UI
 from ..settings.rig import *
 from .misc import *

--- a/menu/menu_physics.py
+++ b/menu/menu_physics.py
@@ -189,7 +189,7 @@ class PANEL_PT_MustardUI_Physics(MainPanel, bpy.types.Panel):
                 items = [x for x in physics_settings.items if x.object]
                 for on in [x.object.name for x in items if x.object != pi.object]:
                     if check_mirror(pi.object.name, on, left=True) or check_mirror(pi.object.name, on, left=False):
-                        row.enabled = pi.enable and True
+                        row.enabled = pi.enable
                 row.operator("mustardui.physics_mirror", text="", icon="MOD_MIRROR").obj_name = pi.object.name
 
             if pi.type in ["CAGE", "SINGLE_ITEM"]:

--- a/menu/menu_settings.py
+++ b/menu/menu_settings.py
@@ -34,7 +34,10 @@ class PANEL_PT_MustardUI_SettingsPanel(MainPanel, bpy.types.Panel):
         if rig_settings.model_version != '':
             box = layout.box()
             box.label(text="Model Version: ", icon="INFO")
-            box.label(text=rig_settings.model_version, icon="BLANK1")
+            version = rig_settings.model_version
+            if rig_settings.model_version_date_enable and rig_settings.model_version_date != "":
+                version = version + ' - ' + rig_settings.model_version_date
+            box.label(text=version, icon="BLANK1")
 
 
 def register():

--- a/menu/menu_warnings.py
+++ b/menu/menu_warnings.py
@@ -34,7 +34,6 @@ class PANEL_PT_MustardUI_Warnings(MainPanel, bpy.types.Panel):
     def draw(self, context):
 
         settings = bpy.context.scene.MustardUI_Settings
-        poll, obj = mustardui_active_object(context, config=0)
 
         layout = self.layout
 

--- a/physics/ops_cache.py
+++ b/physics/ops_cache.py
@@ -5,7 +5,7 @@ from ..model_selection.active_object import *
 class MustardUI_Physics_SyncFrames(bpy.types.Operator):
     """Synchronise the physics bake frames with the scene ones"""
     bl_idname = "mustardui.physics_bake_syncframes"
-    bl_label = "Synchornise frames with scene"
+    bl_label = "Synchronise frames with scene"
 
     @classmethod
     def poll(cls, context):

--- a/physics/settings_item.py
+++ b/physics/settings_item.py
@@ -86,7 +86,6 @@ class MustardUI_PhysicsItem(bpy.types.PropertyGroup):
     collapse_collisions: bpy.props.BoolProperty(default=True, name="")
 
 
-
 def register():
     bpy.utils.register_class(MustardUI_PhysicsItem)
 

--- a/physics/ui_list_menu.py
+++ b/physics/ui_list_menu.py
@@ -19,11 +19,12 @@ class MUSTARDUI_UL_PhysicsItems_UIList_Menu(bpy.types.UIList):
         name = name if not rig_settings.model_MustardUI_naming_convention else name[len(rig_settings.model_name)+1:]
         layout.label(text=name, icon=mustardui_physics_item_type_dict[item.type])
         row = layout.row(align=True)
-        row.prop(item, 'enable', text="", icon="PHYSICS")
         if item.type in ["CAGE", "SINGLE_ITEM"]:
+            row.prop(item, 'enable', text="", icon="PHYSICS")
             row.prop(item, 'collisions', text="", icon="MOD_PHYSICS")
         else:
             row.label(text="", icon="BLANK1")
+            row.prop(item, 'enable', text="", icon="MOD_PHYSICS")
         row.prop(item.object, 'hide_viewport', text="")
 
 

--- a/physics/update_enable.py
+++ b/physics/update_enable.py
@@ -51,6 +51,10 @@ def enable_physics_update(self, context):
             set_modifiers(pi, rig_settings.model_body, status)
         if not status:
             pi.object.hide_viewport = True
+        if not self.enable_physics:
+            pi.collapse_cloth = True
+            pi.collapse_softbody = True
+            pi.collapse_collisions = True
 
     for coll in [x for x in rig_settings.outfits_collections if x.collection is not None]:
         items = coll.collection.all_objects if rig_settings.outfit_config_subcollections else coll.collection.objects
@@ -115,6 +119,11 @@ def enable_physics_update_single(self, context):
 
     if not status:
         self.object.hide_viewport = True
+
+    if not self.enable:
+        self.collapse_cloth = True
+        self.collapse_softbody = True
+        self.collapse_collisions = True
 
     return
 

--- a/physics/update_enable.py
+++ b/physics/update_enable.py
@@ -60,11 +60,19 @@ def enable_physics_update(self, context):
                 set_cage_modifiers(pi, obj.modifiers, status)
                 set_modifiers(pi, obj, status)
 
-    for obj in [x for x in rig_settings.hair_collection.objects if x.type == "MESH"]:
-        for pi in [x for x in self.items if x.type == "CAGE"]:
-            status = self.enable_physics and pi.enable
-            set_cage_modifiers(pi, obj.modifiers, status)
-            set_modifiers(pi, obj, status)
+    if rig_settings.hair_collection is not None:
+        for obj in [x for x in rig_settings.hair_collection.objects if x.type == "MESH"]:
+            for pi in [x for x in self.items if x.type == "CAGE"]:
+                status = self.enable_physics and pi.enable
+                set_cage_modifiers(pi, obj.modifiers, status)
+                set_modifiers(pi, obj, status)
+
+    if rig_settings.extras_collection is not None:
+        for obj in [x for x in rig_settings.extras_collection.objects if x.type == "MESH"]:
+            for pi in [x for x in self.items if x.type == "CAGE"]:
+                status = self.enable_physics and pi.enable
+                set_cage_modifiers(pi, obj.modifiers, status)
+                set_modifiers(pi, obj, status)
 
     return
 
@@ -95,9 +103,15 @@ def enable_physics_update_single(self, context):
                 set_cage_modifiers(self, obj.modifiers, status)
                 set_modifiers(self, obj, status)
 
-        for obj in [x for x in rig_settings.hair_collection.objects if x.type == "MESH"]:
-            set_cage_modifiers(self, obj.modifiers, status)
-            set_modifiers(self, obj, status)
+        if rig_settings.extras_collection is not None:
+            for obj in [x for x in rig_settings.extras_collection.objects if x.type == "MESH"]:
+                set_cage_modifiers(self, obj.modifiers, status)
+                set_modifiers(self, obj, status)
+
+        if rig_settings.hair_collection is not None:
+            for obj in [x for x in rig_settings.hair_collection.objects if x.type == "MESH"]:
+                set_cage_modifiers(self, obj.modifiers, status)
+                set_modifiers(self, obj, status)
 
     if not status:
         self.object.hide_viewport = True

--- a/settings/outfit.py
+++ b/settings/outfit.py
@@ -1,38 +1,60 @@
 import bpy
-from bpy.props import *
 
 
 # Outfit information
 class MustardUI_Outfit(bpy.types.PropertyGroup):
     # Collection storing the outfit pieces
-    collection: PointerProperty(name="Outfit Collection",
-                                type=bpy.types.Collection)
+    collection: bpy.props.PointerProperty(name="Outfit Collection",
+                                          type=bpy.types.Collection)
+
+
+class MustardUI_OutfitSettings(bpy.types.PropertyGroup):
+
+    # Function to enable/disable physics for the single outfit
+    def update_physics(self, context):
+        if self.id_data.modifiers is None:
+            return
+
+        for m in self.id_data.modifiers:
+            if m.type in ["CLOTH", "SOFT_BODY"]:
+                m.show_viewport = self.physics
+                m.show_render = self.physics
+            elif m.type in ["COLLISION"]:
+                self.id_data.collision.use = self.physics
+
+    physics: bpy.props.BoolProperty(default=False,
+                                    name="Enable Physics",
+                                    description="Enable Physics on the current Outfit piece",
+                                    update=update_physics)
+
+    # Variable to collapse children in Outfit pieces list
+    collapse_children: bpy.props.BoolProperty(default=True, description="", name="")
+
+    # Custom properties show
+    additional_options_show: bpy.props.BoolProperty(default=False,
+                                                    name="",
+                                                    description="Show additional properties for the selected object")
+    additional_options_show_lock: bpy.props.BoolProperty(default=False,
+                                                         name="",
+                                                         description="Show additional properties for the selected object")
 
 
 def register():
     bpy.utils.register_class(MustardUI_Outfit)
+    bpy.utils.register_class(MustardUI_OutfitSettings)
 
-    # Properties and model_selection specific to objects
-    bpy.types.Object.MustardUI_additional_options_show = BoolProperty(default=False,
-                                                                      name="",
-                                                                      description="Show additional properties for the "
-                                                                                  "selected object")
-    bpy.types.Object.MustardUI_additional_options_show_lock = BoolProperty(default=False,
-                                                                           name="",
-                                                                           description="Show additional properties for "
-                                                                                       "the selected object")
-    bpy.types.Object.MustardUI_outfit_visibility = BoolProperty(default=False, name="")
-    bpy.types.Object.MustardUI_outfit_collapse_children = BoolProperty(default=True, name="")
+    bpy.types.Object.MustardUI_OutfitSettings = bpy.props.PointerProperty(type=MustardUI_OutfitSettings)
 
-    bpy.types.Object.MustardUI_outfit_lock = BoolProperty(default=False,
-                                                          name="",
-                                                          description="Lock/unlock the outfit")
+    bpy.types.Object.MustardUI_outfit_visibility = bpy.props.BoolProperty(default=False, name="")
+
+    bpy.types.Object.MustardUI_outfit_lock = bpy.props.BoolProperty(default=False,
+                                                                    name="",
+                                                                    description="Lock/unlock the outfit")
 
 
 def unregister():
     del bpy.types.Object.MustardUI_outfit_visibility
-    del bpy.types.Object.MustardUI_outfit_collapse_children
-    del bpy.types.Object.MustardUI_additional_options_show_lock
-    del bpy.types.Object.MustardUI_additional_options_show
+
+    del bpy.types.Object.MustardUI_OutfitSettings
 
     bpy.utils.unregister_class(MustardUI_Outfit)

--- a/settings/rig.py
+++ b/settings/rig.py
@@ -566,6 +566,10 @@ class MustardUI_RigSettings(bpy.types.PropertyGroup):
                                                            description="Disable Armature modifiers of Outfits that "
                                                                        "are not visible to increase performance")
 
+    outfit_physics_support: bpy.props.BoolProperty(default=True,
+                                                   name="Enable Outfit Physics support",
+                                                   description="If enabled, a button near outfit pieces with Physics modifiers is added to enable/disable physics")
+
     # Extras
     def poll_collection_extras(self, object):
         if self.hair_collection is not None:

--- a/settings/rig.py
+++ b/settings/rig.py
@@ -1102,6 +1102,10 @@ class MustardUI_RigSettings(bpy.types.PropertyGroup):
     model_version: bpy.props.StringProperty(name="Model version",
                                             description="Version of the model",
                                             default="")
+    model_version_date_enable: bpy.props.BoolProperty(name="Add Date to version",
+                                                      description="Automatically add the date to the version when ending Configuration mode",
+                                                      default=False)
+    model_version_date: bpy.props.StringProperty(default="")
 
     # Object and Collection MustardUI naming convention
     model_MustardUI_naming_convention: bpy.props.BoolProperty(default=True,

--- a/tools_creators/ops_collision_cage.py
+++ b/tools_creators/ops_collision_cage.py
@@ -54,6 +54,7 @@ class MustardUI_ToolsCreators_CreateCollisionCage(bpy.types.Operator):
     def execute(self, context):
 
         res, obj = mustardui_active_object(context, config=1)
+        rig_settings = obj.MustardUI_RigSettings
         physics_settings = obj.MustardUI_PhysicsSettings
 
         def add_driver(source, target, prop, data_path, index=-1):
@@ -103,7 +104,7 @@ class MustardUI_ToolsCreators_CreateCollisionCage(bpy.types.Operator):
             bpy.context.view_layer.objects.active = obj
             bpy.ops.object.duplicate(linked=True)
             duplicate_obj = bpy.context.active_object
-            duplicate_obj.name = f"{obj.name} Proxy"
+            duplicate_obj.name = f"{obj.name} Collision Cage"
 
             # Clear existing custom property
             if "Inflate" in obj.keys():
@@ -271,6 +272,8 @@ class MustardUI_ToolsCreators_CreateCollisionCage(bpy.types.Operator):
         if self.add_to_panel:
             add_item = physics_settings.items.add()
             add_item.object = bpy.context.object
+            if rig_settings.model_name != "":
+                add_item.object.name = f"{rig_settings.model_name} {add_item.object.name}"
             add_item.type = 'COLLISION'
 
         self.report({'INFO'}, 'MustardUI - Collision Cage created.')


### PR DESCRIPTION
- **Feature**: added possibility to turn on and off the physics on Outfit pieces (cloth, soft body, collisions)
- **Feature**: possibility to automatically add the date to the model version in Configuration mode
- **Enhancement**: frames in physics cache tool also updates outfits, extras and hair (cloth, soft body, collisions, particle systems)
- **Enhancement**: MustardUI Naming Convention option moved after the model name and body
- **Enhancement**: on the Jiggle Cage creator tool, it is now it's possible to specify direction of cage pin group
- **Enhancement**: on the Jiggle Cage creator tool, an option to parent the resulting cage to the armature Object has been added
- **Enhancement**: enabling/disabling global physics or single items now collapses the physics menu, to avoid cluttering the UI
- **Bug**: fixed issue with Extras not being updated when physics was activated/deactivated
- **Bug**: fixed outfit pieces custom properties button also affecting the same piece in the locked list (and viceversa)
- **Bug**: other small bug fixes