### PR TITLE
Version 2025.6.2

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2025, 6, 1),
+    "version": (2025, 6, 2),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/armature/definitions.py
+++ b/armature/definitions.py
@@ -2,6 +2,7 @@ import bpy
 from bpy.props import *
 from ..model_selection.active_object import *
 from ..misc.icons_list import mustardui_icon_list
+from ..misc.outfits import outfit_poll_collection, outfit_poll_mesh
 
 
 # Class for single bone collection
@@ -34,25 +35,6 @@ class MustardUI_ArmatureBoneCollection(bpy.types.PropertyGroup):
             self.default = False
         return
 
-    # Poll function for the selection of mesh belonging to an outfit in pointer properties
-    def outfit_switcher_poll_collection(self, object):
-        rig_settings = self.id_data.MustardUI_RigSettings
-        collections = [x.collection for x in rig_settings.outfits_collections if x.collection is not None]
-        if rig_settings.extras_collection is not None:
-            collections.append(rig_settings.extras_collection)
-        if rig_settings.hair_collection is not None:
-            collections.append(rig_settings.hair_collection)
-        return object in collections
-
-    # Poll function for the selection of mesh belonging to an outfit in pointer properties
-    def outfit_switcher_poll_mesh(self, object):
-        rig_settings = self.id_data.MustardUI_RigSettings
-        if self.outfit_switcher_collection is not None:
-            items = self.outfit_switcher_collection.all_objects if rig_settings.outfit_config_subcollections else self.outfit_switcher_collection.objects
-            if object in [x for x in items]:
-                return object.type == 'MESH'
-        return False
-
     # Automatic outfits layer switcher
     outfit_switcher_enable: bpy.props.BoolProperty(default=False,
                                                    name="Outfit Switcher",
@@ -69,13 +51,13 @@ class MustardUI_ArmatureBoneCollection(bpy.types.PropertyGroup):
                                                                       "you want the layer to be shown only for a "
                                                                       "specific outfit piece/hair object",
                                                           type=bpy.types.Collection,
-                                                          poll=outfit_switcher_poll_collection)
+                                                          poll=outfit_poll_collection)
 
     outfit_switcher_object: bpy.props.PointerProperty(name="Outfit Piece/Hair",
                                                       description="When switching to this specific outfit piece/hair "
                                                                   "object, the layer will be shown/hidden",
                                                       type=bpy.types.Object,
-                                                      poll=outfit_switcher_poll_mesh)
+                                                      poll=outfit_poll_mesh)
 
     # Children
     # Button to show children of the bone

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2025.6.1"
+version = "2025.6.2"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/custom_properties/menus.py
+++ b/custom_properties/menus.py
@@ -19,6 +19,7 @@ class OUTLINER_MT_MustardUI_PropertySectionMenu(bpy.types.Menu):
             op.section = sec.name
             op.outfit = ""
             op.outfit_piece = ""
+            op.hair_global = False
             op.hair = ""
 
 
@@ -41,6 +42,7 @@ class OUTLINER_MT_MustardUI_PropertyOutfitPieceMenu(bpy.types.Menu):
             op.section = ""
             op.outfit = context.mustardui_propertyoutfitmenu_sel.name
             op.outfit_piece = ""
+            op.hair_global = False
             op.hair = ""
 
         items = context.mustardui_propertyoutfitmenu_sel.all_objects if rig_settings.outfit_config_subcollections else context.mustardui_propertyoutfitmenu_sel.objects
@@ -52,6 +54,7 @@ class OUTLINER_MT_MustardUI_PropertyOutfitPieceMenu(bpy.types.Menu):
             op.section = ""
             op.outfit = context.mustardui_propertyoutfitmenu_sel.name
             op.outfit_piece = obj.name
+            op.hair_global = False
             op.hair = ""
 
 
@@ -101,6 +104,15 @@ class OUTLINER_MT_MustardUI_PropertyHairMenu(bpy.types.Menu):
 
         layout = self.layout
 
+        op = layout.operator(MustardUI_Property_MenuAdd.bl_idname,
+                             text="Add as Hair Global property",
+                             icon="TRIA_RIGHT")
+        op.section = ""
+        op.outfit = ""
+        op.outfit_piece = ""
+        op.hair_global = True
+        op.hair = ""
+
         for obj in [x for x in rig_settings.hair_collection.objects if x.type == "MESH"]:
             op = layout.operator(MustardUI_Property_MenuAdd.bl_idname,
                                  icon="STRANDS",
@@ -109,6 +121,7 @@ class OUTLINER_MT_MustardUI_PropertyHairMenu(bpy.types.Menu):
             op.section = ""
             op.outfit = ""
             op.outfit_piece = ""
+            op.hair_global = False
             op.hair = obj.name
 
 

--- a/custom_properties/menus.py
+++ b/custom_properties/menus.py
@@ -190,16 +190,21 @@ class MUSTARDUI_MT_Property_LinkMenu(bpy.types.Menu):
             op.type = "OUTFIT"
             no_prop = False
 
-        hair_props = [x for x in obj.MustardUI_CustomPropertiesHair if x.is_animatable and x.hair is not None]
+        hair_props = [x for x in obj.MustardUI_CustomPropertiesHair if x.is_animatable]
         if len(hair_props) > 0 and (len(outfit_props) > 0 or len(body_props) > 0):
             layout.separator()
             layout.label(text="Hair", icon="STRANDS")
         for prop in sorted(hair_props, key=lambda x: x.name):
-            hair_name = prop.hair.name[
-                        len(rig_settings.hair_collection.name + " "):] if rig_settings.model_MustardUI_naming_convention else prop.hair.name
-            op = layout.operator(MustardUI_Property_MenuLink.bl_idname,
-                                 text=hair_name + " - " + prop.name,
-                                 icon=prop.icon)
+            if prop.hair is not None:
+                hair_name = prop.hair.name[
+                            len(rig_settings.hair_collection.name + " "):] if rig_settings.model_MustardUI_naming_convention else prop.hair.name
+                op = layout.operator(MustardUI_Property_MenuLink.bl_idname,
+                                     text=hair_name + " - " + prop.name,
+                                     icon=prop.icon)
+            else:
+                op = layout.operator(MustardUI_Property_MenuLink.bl_idname,
+                                     text="Global - " + prop.name,
+                                     icon=prop.icon)
             op.parent_rna = prop.rna
             op.parent_path = prop.path
             op.type = "HAIR"

--- a/custom_properties/ops_props.py
+++ b/custom_properties/ops_props.py
@@ -17,6 +17,7 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
     outfit: StringProperty(default="")
     outfit_piece: StringProperty(default="")
     hair: StringProperty(default="")
+    hair_global: BoolProperty(default=False)
 
     @classmethod
     def poll(cls, context):
@@ -29,7 +30,7 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
         res, obj = mustardui_active_object(context, config=1)
         if self.outfit != "":
             custom_props = obj.MustardUI_CustomPropertiesOutfit
-        elif self.hair != "":
+        elif self.hair != "" or self.hair_global:
             custom_props = obj.MustardUI_CustomPropertiesHair
         else:
             custom_props = obj.MustardUI_CustomProperties
@@ -171,7 +172,7 @@ class MustardUI_Property_MenuAdd(bpy.types.Operator):
             # Assign type
             if self.outfit != "":
                 cp.cp_type = "OUTFIT"
-            elif self.hair != "":
+            elif self.hair != "" or self.hair_global:
                 cp.cp_type = "HAIR"
             else:
                 cp.cp_type = "BODY"

--- a/menu/menu_configure_physics.py
+++ b/menu/menu_configure_physics.py
@@ -65,6 +65,13 @@ class PANEL_PT_MustardUI_InitPanel_Physics(MainPanel, bpy.types.Panel):
                 row = col.row()
                 row.prop(pi, 'type')
 
+                col = box.column(align=True)
+                col.prop(pi, 'outfit_enable')
+                if pi.outfit_enable:
+                    col.prop(pi, 'outfit_collection', text="Collection")
+                    if pi.outfit_collection is not None:
+                        col.prop(pi, 'outfit_object', text="Object")
+
             if settings.advanced and index > -1 and len(
                     physics_settings.items[arm.mustardui_physics_items_uilist_index].intersecting_objects) > 0:
                 box = layout.box()

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -30,11 +30,12 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
             rig_settings = arm.MustardUI_RigSettings
 
             # Check if one of these should be shown in the UI
+            hair_global_properties_avail = len([x for x in arm.MustardUI_CustomPropertiesHair if x.hair is None])
             hair_avail = len([x for x in rig_settings.hair_collection.objects if x.type == "MESH"]) > 0 if rig_settings.hair_collection is not None else False
             particle_avail = len([x for x in rig_settings.model_body.modifiers if x.type == "PARTICLE_SYSTEM"]) > 0 and rig_settings.particle_systems_enable if rig_settings.model_body is not None else False
             curved_hair = len([x for x in rig_settings.hair_collection.objects if x.type == "CURVES"]) > 0 if rig_settings.hair_collection is not None else False
 
-            return res if (hair_avail or particle_avail or curved_hair) else False
+            return res if (hair_avail or particle_avail or curved_hair or hair_global_properties_avail) else False
 
         return res
 
@@ -49,13 +50,13 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
         layout = self.layout
 
         # Hair
-        hair_gloabal_properties = [x for x in arm.MustardUI_CustomPropertiesHair if x.hair is None]
-        if len(hair_gloabal_properties) > 0:
+        hair_global_properties = [x for x in arm.MustardUI_CustomPropertiesHair if x.hair is None]
+        if len(hair_global_properties) > 0:
             box = layout.box()
             row = box.row(align=True)
             row.label(text="Global settings", icon="MODIFIER")
 
-            mustardui_custom_properties_print(arm, settings, hair_gloabal_properties, box,
+            mustardui_custom_properties_print(arm, settings, hair_global_properties, box,
                                           rig_settings.hair_custom_properties_icons)
 
         if rig_settings.hair_collection is not None:

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -49,6 +49,15 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
         layout = self.layout
 
         # Hair
+        hair_gloabal_properties = [x for x in arm.MustardUI_CustomPropertiesHair if x.hair is None]
+        if len(hair_gloabal_properties) > 0:
+            box = layout.box()
+            row = box.row(align=True)
+            row.label(text="Global settings", icon="MODIFIER")
+
+            mustardui_custom_properties_print(arm, settings, hair_gloabal_properties, box,
+                                          rig_settings.hair_custom_properties_icons)
+
         if rig_settings.hair_collection is not None:
 
             hair_num = len([x for x in rig_settings.hair_collection.objects if x.type == "MESH"])

--- a/menu/menu_morphs.py
+++ b/menu/menu_morphs.py
@@ -456,7 +456,7 @@ class PANEL_PT_MustardUI_Morphs_Custom(MainPanel, bpy.types.Panel):
         for section in [x for x in morphs_settings.sections if x.morphs and not x.is_internal]:
             box = layout.box()
             if ui_collapse_prop(box, section, 'collapse', section.name, icon=section.icon):
-                for morph in section.morphs:
+                for morph in [x for x in section.morphs if morph_filter(x, rig_settings, morphs_settings)]:
                     cp_source = get_cp_source(morph.custom_property_source, rig_settings)
                     if cp_source and morph.custom_property and hasattr(cp_source, f'["{bpy.utils.escape_identifier(morph.path)}"]'):
                         box.prop(cp_source, f'["{bpy.utils.escape_identifier(morph.path)}"]', text=morph.name)

--- a/misc/outfits.py
+++ b/misc/outfits.py
@@ -1,0 +1,38 @@
+import bpy
+
+
+def outfit_poll_collection(self, object):
+    rig_settings = self.id_data.MustardUI_RigSettings
+    collections = [x.collection for x in rig_settings.outfits_collections if x.collection is not None]
+    if rig_settings.extras_collection is not None:
+        collections.append(rig_settings.extras_collection)
+    if rig_settings.hair_collection is not None:
+        collections.append(rig_settings.hair_collection)
+    return object in collections
+
+
+# Poll function for the selection of mesh belonging to an outfit in pointer properties
+def outfit_poll_mesh(self, object):
+    rig_settings = self.id_data.MustardUI_RigSettings
+    if self.outfit_switcher_collection is not None:
+        items = self.outfit_switcher_collection.all_objects if rig_settings.outfit_config_subcollections else self.outfit_switcher_collection.objects
+        if object in [x for x in items]:
+            return object.type == 'MESH'
+    return False
+
+def outfit_poll_mesh_physics(self, object):
+    rig_settings = self.id_data.MustardUI_RigSettings
+    physics_settings = self.id_data.MustardUI_PhysicsSettings
+    if self.outfit_collection is not None:
+        physics_items = [x.object for x in physics_settings.items]
+        items = []
+        for obj in (self.outfit_collection.all_objects if rig_settings.outfit_config_subcollections else self.outfit_collection.objects):
+            if obj not in physics_items:
+                items.append(obj)
+        for children in [x.children for x in items]:
+            for obj in children:
+                if obj not in physics_items:
+                    items.append(obj)
+        if object in [x for x in items] and object != self.object:
+            return object.type == 'MESH'
+    return False

--- a/physics/settings_item.py
+++ b/physics/settings_item.py
@@ -1,6 +1,7 @@
 import bpy
 from ..model_selection.active_object import *
 from .update_enable import *
+from ..misc.outfits import outfit_poll_mesh_physics, outfit_poll_collection
 
 
 def poll_mesh(self, o):
@@ -14,14 +15,22 @@ def poll_mesh_linked(self, o):
     res, obj = mustardui_active_object(bpy.context, config=1)
     physics_settings = obj.MustardUI_PhysicsSettings
 
-    return o.type == 'MESH' and (o in [x.object for x in physics_settings.items if x.type == "CAGE"]) and o != self.object
+    return o.type == 'MESH' and (
+            o in [x.object for x in physics_settings.items if x.type == "CAGE"]) and o != self.object
 
 
 mustardui_physics_item_type = [("NONE", "None", "Disable Physics", "BLANK1", 0),
-                               ("CAGE", "Cage", "A mesh that modifies another one through Mesh or Surface Deform modifiers", "MESH_UVSPHERE", 1),
-                               ("COLLISION", "Collision", "A mesh that acts as collision for other meshes", "MOD_PHYSICS", 2),
-                               ("SINGLE_ITEM", "Single Item", "An item that does not need Mesh or Surface Deform modifiers on the Body or the Outfits", "OBJECT_ORIGIN", 3),
-                               ("BONES_DRIVER", "Bone Driver", "An item that drives the motion of bones through Constraints.\nOnly constraints with 'target' are supported", "BONE_DATA", 4)]
+                               ("CAGE", "Cage",
+                                "A mesh that modifies another one through Mesh or Surface Deform modifiers",
+                                "MESH_UVSPHERE", 1),
+                               ("COLLISION", "Collision", "A mesh that acts as collision for other meshes",
+                                "MOD_PHYSICS", 2),
+                               ("SINGLE_ITEM", "Single Item",
+                                "An item that does not need Mesh or Surface Deform modifiers on the Body or the Outfits",
+                                "OBJECT_ORIGIN", 3),
+                               ("BONES_DRIVER", "Bone Driver",
+                                "An item that drives the motion of bones through Constraints.\nOnly constraints with 'target' are supported",
+                                "BONE_DATA", 4)]
 mustardui_physics_item_type_dict = {
     "NONE": "BLANK1",
     "CAGE": "MESH_UVSPHERE",
@@ -36,7 +45,6 @@ class MustardUI_PhysicsItem_Intersecting(bpy.types.PropertyGroup):
 
 
 class MustardUI_PhysicsItem(bpy.types.PropertyGroup):
-
     enable: bpy.props.BoolProperty(default=False,
                                    name="Enable Physics",
                                    update=enable_physics_update_single)
@@ -53,6 +61,23 @@ class MustardUI_PhysicsItem(bpy.types.PropertyGroup):
                                  items=mustardui_physics_item_type,
                                  name="Type")
 
+    # Outfits support
+    outfit_enable: bpy.props.BoolProperty(default=False,
+                                          name="Outfit Physics",
+                                          description="Assign this Physics Item to an outfit.\n The outfit will be "
+                                                      "shown near the Outfit piece instead of the Physics Items list")
+
+    outfit_collection: bpy.props.PointerProperty(name="Outfit/Hair",
+                                                 description="Outfit/Hair collection",
+                                                 type=bpy.types.Collection,
+                                                 poll=outfit_poll_collection)
+
+    outfit_object: bpy.props.PointerProperty(name="Outfit Piece/Hair",
+                                             description="Specific Outfit/hair piece",
+                                             type=bpy.types.Object,
+                                             poll=outfit_poll_mesh_physics)
+
+    # UI switchers
     collisions: bpy.props.BoolProperty(default=False,
                                        name="Collisions",
                                        description="Enable/disable collisions on the modifiers",


### PR DESCRIPTION
- **Feature**: Physics items can now be assigned to Outfit and Hair pieces, adding a physics button directly in the Outfit/Hair panels.
- **Feature**: Custom properties can now be added as Global Hair properties, and will be shown at the top of the Hair panel.
- **Fix**: Custom Morphs were not affected by the name filter in the Morphs panel.