### PR TITLE
Version 2025.6.4

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2025, 6, 2),
+    "version": (2025, 6, 3),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2025, 6, 3),
+    "version": (2025, 6, 4),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2025.6.2"
+version = "2025.6.3"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2025.6.3"
+version = "2025.6.4"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/menu/menu_configure_outfit.py
+++ b/menu/menu_configure_outfit.py
@@ -38,7 +38,6 @@ class PANEL_PT_MustardUI_InitPanel_Outfit(MainPanel, bpy.types.Panel):
         col.prop(rig_settings, "outfit_nude")
         col.prop(rig_settings, "outfit_physics_support", text="Physics Support")
         col.prop(rig_settings, "outfit_config_subcollections")
-        col.prop(rig_settings, "outfit_additional_options")
 
         if settings.advanced:
             col.separator()

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -91,7 +91,7 @@ class PANEL_PT_MustardUI_Hair(MainPanel, bpy.types.Panel):
                                                        key=lambda x: x.name)
                     else:
                         custom_properties_obj = [x for x in arm.MustardUI_CustomPropertiesHair if x.hair == obj]
-                    if len(custom_properties_obj) > 0 and rig_settings.outfit_additional_options:
+                    if len(custom_properties_obj) > 0:
                         row.prop(obj.MustardUI_OutfitSettings, "additional_options_show", toggle=True, icon="PREFERENCES")
                         if obj.MustardUI_OutfitSettings.additional_options_show:
                             mustardui_custom_properties_print(arm, settings, custom_properties_obj, box,

--- a/menu/menu_outfits.py
+++ b/menu/menu_outfits.py
@@ -84,7 +84,7 @@ def draw_outfit_piece(layout, obj, arm, rig_settings, physics_settings, settings
         custom_properties_obj = [x for x in arm.MustardUI_CustomPropertiesOutfit if
                                  (x.outfit == co_coll if otype != 1 else True) and x.outfit_piece == obj and not x.hidden]
 
-    if len(custom_properties_obj) > 0 and rig_settings.outfit_additional_options:
+    if len(custom_properties_obj) > 0:
         row.prop(obj.MustardUI_OutfitSettings, "additional_options_show" if otype != 1 else "additional_options_show_lock", toggle=True, icon="PREFERENCES")
         check_show = obj.MustardUI_OutfitSettings.additional_options_show if otype != 1 else obj.MustardUI_OutfitSettings.additional_options_show_lock
         if check_show:
@@ -171,7 +171,7 @@ class PANEL_PT_MustardUI_Outfits(MainPanel, bpy.types.Panel):
                                                  rig_settings.outfits_list] and x.outfit_piece is None and not x.hidden and (
                                                  not x.advanced if not settings.advanced else True)]
 
-                    if len(custom_properties) > 0 and rig_settings.outfit_additional_options:
+                    if len(custom_properties) > 0:
                         row.prop(rig_settings, "outfit_global_custom_properties_collapse", text="", toggle=True,
                                  icon="PREFERENCES")
                         if rig_settings.outfit_global_custom_properties_collapse:

--- a/morphs/misc.py
+++ b/morphs/misc.py
@@ -1,5 +1,5 @@
 # Function to add a option to the object, if not already there
-def mustardui_add_morph(collection, item, custom_property=True, custom_property_source="ARMATURE"):
+def mustardui_add_morph(collection, item, custom_property=True, custom_property_source="ARMATURE_OBJ"):
     for el in collection:
         if el.path == item[1] and el.custom_property == custom_property:
             return

--- a/morphs/ops_defvalue.py
+++ b/morphs/ops_defvalue.py
@@ -1,5 +1,6 @@
 import bpy
 from ..model_selection.active_object import *
+from .misc import get_cp_source
 
 
 class MustardUI_DazMorphs_DefaultValues(bpy.types.Operator):
@@ -21,18 +22,27 @@ class MustardUI_DazMorphs_DefaultValues(bpy.types.Operator):
 
         for section in morphs_settings.sections:
             for morph in section.morphs:
-                if morph.custom_property:
-                    val = rig_settings.model_armature_object[morph.path]
+                cp_source = get_cp_source(morph.custom_property_source, rig_settings)
+                if cp_source and morph.custom_property and hasattr(cp_source,
+                                                          f'["{bpy.utils.escape_identifier(morph.path)}"]'):
+                    val = cp_source[morph.path]
                     if isinstance(val, float):
-                        rig_settings.model_armature_object[morph.path] = 0.
+                        cp_source[morph.path] = 0.
                     elif isinstance(val, bool):
-                        rig_settings.model_armature_object[morph.path] = True
+                        cp_source[morph.path] = True
                 elif morph.shape_key:
                     rig_settings.data.shape_keys.key_blocks[morph.path].value = 0.
 
+        if arm:
+            arm.update_tag()
+        if rig_settings.model_armature_object:
+            rig_settings.model_armature_object.update_tag()
+        if rig_settings.model_body:
+            rig_settings.model_body.update_tag()
+            if rig_settings.model_body.data:
+                rig_settings.model_body.data.update_tag()
 
-        arm.update_tag()
-        rig_settings.model_armature_object.update_tag()
+        bpy.context.view_layer.update()
 
         self.report({'INFO'}, 'MustardUI - Morphs values restored to default.')
 

--- a/settings/rig.py
+++ b/settings/rig.py
@@ -539,9 +539,6 @@ class MustardUI_RigSettings(bpy.types.PropertyGroup):
                                                                         "the Outfits",
                                                             update=outfits_global_options_update)
 
-    outfit_additional_options: bpy.props.BoolProperty(default=True,
-                                                      name="Custom properties",
-                                                      description="Enable custom properties for outfits")
     outfit_custom_properties_icons: bpy.props.BoolProperty(default=False,
                                                            name="Show Icons",
                                                            description="Enable properties icons in the outfit menu")


### PR DESCRIPTION
- **Fix** (#262): Custom properties for Hair do not appear if Custom Properties option for Outfit is not active. To solve the issue, the latter option has been removed. Now Custom properties are always shown.
-  **Fix**: An error occurs when using restore morphs to default value for custom morphs.