### PR TITLE
Fix some encountered bugs

### DIFF
--- a/armature/ops_reset.py
+++ b/armature/ops_reset.py
@@ -27,6 +27,12 @@ class MustardUI_Armature_ResetCollections(bpy.types.Operator):
             )
             coll.is_solo = False
 
+        # outfits visibility sync, (hair does not seem to be affected by the reset)
+        arm = obj.MustardUI_ArmatureSettings
+
+        arm.mustardui_armature_visibility_outfits_update(context)
+        # arm.mustardui_armature_visibility_hair_update(context)
+
         return {"FINISHED"}
 
 

--- a/armature/ops_reset.py
+++ b/armature/ops_reset.py
@@ -27,11 +27,10 @@ class MustardUI_Armature_ResetCollections(bpy.types.Operator):
             )
             coll.is_solo = False
 
-        # outfits visibility sync, (hair does not seem to be affected by the reset)
+        # Outfits visibility sync, (Hair does not seem to be affected by the reset)
         arm = obj.MustardUI_ArmatureSettings
 
         arm.mustardui_armature_visibility_outfits_update(context)
-        # arm.mustardui_armature_visibility_hair_update(context)
 
         return {"FINISHED"}
 

--- a/outfits/helper_functions.py
+++ b/outfits/helper_functions.py
@@ -18,10 +18,16 @@ def outfits_update_armature_collections(rig_settings, arm):
 
         visible = False
         for ob in items:
+            # the reason why `bcoll_settings.outfit_switcher_collection.hide_viewport`
+            # and not `not bcoll_settings.outfit_switcher_collection.hide_viewport` is
+            # because bcoll_settings.outfit_switcher_collection.hide_viewport gives
+            # back the old state, meaning if the collection is hidden, and you click
+            # unhide, the value of that variable after clicking is still hidden, so we
+            # should negate it to get the current state if that makes sense ^^'
             if ob == bcoll_settings.outfit_switcher_object:
                 visible = (
                     not ob.hide_viewport
-                    and not bcoll_settings.outfit_switcher_collection.hide_viewport
+                    and bcoll_settings.outfit_switcher_collection.hide_viewport
                 )
                 break
 

--- a/outfits/helper_functions.py
+++ b/outfits/helper_functions.py
@@ -18,16 +18,10 @@ def outfits_update_armature_collections(rig_settings, arm):
 
         visible = False
         for ob in items:
-            # the reason why `bcoll_settings.outfit_switcher_collection.hide_viewport`
-            # and not `not bcoll_settings.outfit_switcher_collection.hide_viewport` is
-            # because bcoll_settings.outfit_switcher_collection.hide_viewport gives
-            # back the old state, meaning if the collection is hidden, and you click
-            # unhide, the value of that variable after clicking is still hidden, so we
-            # should negate it to get the current state if that makes sense ^^'
             if ob == bcoll_settings.outfit_switcher_object:
                 visible = (
                     not ob.hide_viewport
-                    and bcoll_settings.outfit_switcher_collection.hide_viewport
+                    and not bcoll_settings.outfit_switcher_collection.hide_viewport
                 )
                 break
 

--- a/outfits/helper_functions.py
+++ b/outfits/helper_functions.py
@@ -19,13 +19,15 @@ def outfits_update_armature_collections(rig_settings, arm, is_extras_hidden=None
         visible = False
         for ob in items:
             if ob == bcoll_settings.outfit_switcher_object:
-                # if it is an extras item, we should test if the collection
+                # If it is an Extras item, we should test if the collection
                 # is not hidden
                 is_extras_item = False
-                for extra in rig_settings.extras_collection.all_objects:
-                    if ob == extra:
-                        is_extras_item = True
-                        break
+                if rig_settings.extras_collection:
+                    is_extras_item = any(
+                        ob == extra
+                        for extra in rig_settings.extras_collection.all_objects
+                    )
+
                 if is_extras_item:
                     visible = (
                         not ob.hide_viewport

--- a/outfits/helper_functions.py
+++ b/outfits/helper_functions.py
@@ -1,4 +1,4 @@
-def outfits_update_armature_collections(rig_settings, arm):
+def outfits_update_armature_collections(rig_settings, arm, is_extras_hidden=None):
     """Update visibility of armature bone collections like the outfit operator"""
 
     use_subcollections = rig_settings.outfit_config_subcollections
@@ -19,10 +19,24 @@ def outfits_update_armature_collections(rig_settings, arm):
         visible = False
         for ob in items:
             if ob == bcoll_settings.outfit_switcher_object:
-                visible = (
-                    not ob.hide_viewport
-                    and not bcoll_settings.outfit_switcher_collection.hide_viewport
-                )
+                # if it is an extras item, we should test if the collection
+                # is not hidden
+                is_extras_item = False
+                for extra in rig_settings.extras_collection.all_objects:
+                    if ob == extra:
+                        is_extras_item = True
+                        break
+                if is_extras_item:
+                    visible = (
+                        not ob.hide_viewport
+                        and not bcoll_settings.outfit_switcher_collection.hide_viewport
+                        and not is_extras_hidden
+                    )
+                else:
+                    visible = (
+                        not ob.hide_viewport
+                        and not bcoll_settings.outfit_switcher_collection.hide_viewport
+                    )
                 break
 
         if bcoll.is_visible != visible:

--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -167,10 +167,6 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
                     apply_visibility(child)
 
         # ------------------- GLOBAL UPDATES ------------------- #
-        # Armature collections
-        if armature_settings.outfits:
-            outfits_update_armature_collections(rig_settings, arm)
-
         # Physics update
         if physics_settings.enable_ui:
             enable_physics_update(physics_settings, context)
@@ -193,6 +189,12 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
             hidden = all(x.hide_render for x in items)
             set_bool(extras, "hide_viewport", hidden)
             set_bool(extras, "hide_render", hidden)
+
+        # Armature collections
+        # we update the armature collection after we set the collection visibility
+        # and we pass that state (visibility) to the function
+        if armature_settings.outfits:
+            outfits_update_armature_collections(rig_settings, arm, hidden)
 
         self.shift = False
         return {"FINISHED"}

--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -191,10 +191,10 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
             set_bool(extras, "hide_render", hidden)
 
         # Armature collections
-        # we update the armature collection after we set the collection visibility
-        # and we pass that state (visibility) to the function
         if armature_settings.outfits:
-            outfits_update_armature_collections(rig_settings, arm, hidden)
+            outfits_update_armature_collections(
+                rig_settings, arm, is_extras_hidden=hidden
+            )
 
         self.shift = False
         return {"FINISHED"}

--- a/warnings/ops_update_ui.py
+++ b/warnings/ops_update_ui.py
@@ -176,7 +176,16 @@ class MustardUI_UpdateUI(bpy.types.Operator):
                         obj.name = obj.name.replace(f"{rig_settings.model_name} ", "")
 
                         # Replace the name with the new convention
-                        obj.name = f"{hair_collection.name} - " + obj.name
+
+                        # handle the case when the hair and the collection have the
+                        # same name, the _armature_ won't be named correctly
+                        # it will be named: Hair_Collection - Armature, notice the
+                        # missing Hair between - and Armature
+                        is_armature = obj.name == "Armature"
+                        handle_default_hair = "Hair " if is_armature else ""
+                        obj.name = (
+                            f"{hair_collection.name} - {handle_default_hair}" + obj.name
+                        )
 
                 # Fix the list index
                 rig_settings.hair_list = rig_settings.hair_list_make(context)[0][0]

--- a/warnings/ops_update_ui.py
+++ b/warnings/ops_update_ui.py
@@ -182,10 +182,10 @@ class MustardUI_UpdateUI(bpy.types.Operator):
 
                         # Replace the name with the new convention
 
-                        # handle the case when the hair and the collection have the
+                        # Handle the case when the hair and the collection have the
                         # same name, the _armature_ won't be named correctly
-                        # it will be named: Hair_Collection - Armature, notice the
-                        # missing Hair between - and Armature
+                        # It will be named: Hair_Collection - Armature, without any
+                        # hair specification before Armature
                         is_armature = obj.name == "Armature"
                         handle_default_hair = "Hair " if is_armature else ""
                         obj.name = (


### PR DESCRIPTION
the pr tries to fix the following bugs:

- the `update UI` operator when used in an armature hair that have the same name as the collection, the armature name becomes: hair_collection - Armature, and should be: hair_collection - __Hair__ Armature


- `reset layer visibility` operator in armature panel sometimes not working as expected for the outfits layer, since the operator works with the direct blender bone collections, and the outfit "layer" is an abstraction that needs updating separately.


- Extras item bone collection not showing if it is the only one selected, (you have to enable and disable other Extras item to update it)!