### PR TITLE
Version 2026.5.2

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -35,7 +35,7 @@ jobs:
 
     name: Blender ${{ matrix.blender }}
     needs: lint
-    uses: Mustard2/blender-workflows/.github/workflows/blender-build.yml@v2
+    uses: Mustard2/blender-workflows/.github/workflows/blender-build.yml@v3
     with:
       timeout-seconds: 180
       blender-version: ${{ matrix.blender }}

--- a/custom_properties/ops_smartcheck.py
+++ b/custom_properties/ops_smartcheck.py
@@ -118,8 +118,8 @@ def add_custom_property(obj, rna, path, name, type, custom_props, sections_to_re
     # Add driver
     try:
         add_driver(obj, rna, path, prop_name)
-    except Exception:
-        print("MustardUI - Could not add a driver for " + prop_name)
+    except Exception as e:
+        print("MustardUI - Could not add a driver for " + prop_name + ":" + str(e))
         del obj[prop_name]
         return
 
@@ -276,7 +276,7 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
                 if "MustardUI Float" in shape_key.name:
                     add_custom_property(
                         obj,
-                        f'context.scene.objects["{bpy.utils.escape_identifier(rig_settings.model_body.name)}"].data.shape_keys.key_blocks["{bpy.utils.escape_identifier(shape_key.name)}"]',
+                        f'bpy.context.scene.objects["{bpy.utils.escape_identifier(rig_settings.model_body.name)}"].data.shape_keys.key_blocks["{bpy.utils.escape_identifier(shape_key.name)}"]',
                         "value",
                         shape_key.name[len("MustardUI Float - ") :],
                         "FLOAT",
@@ -287,7 +287,7 @@ class MustardUI_Property_SmartCheck(bpy.types.Operator):
                 elif "MustardUI Bool" in shape_key.name:
                     add_custom_property(
                         obj,
-                        f'context.scene.objects["{bpy.utils.escape_identifier(rig_settings.model_body.name)}"].data.shape_keys.key_blocks["{bpy.utils.escape_identifier(shape_key.name)}"]',
+                        f'bpy.context.scene.objects["{bpy.utils.escape_identifier(rig_settings.model_body.name)}"].data.shape_keys.key_blocks["{bpy.utils.escape_identifier(shape_key.name)}"]',
                         "value",
                         shape_key.name[len("MustardUI Bool - ") :],
                         "BOOL",

--- a/presets/misc.py
+++ b/presets/misc.py
@@ -1,4 +1,4 @@
-from .. import bl_info
+from .version import PRESETS_VERSION
 
 
 def get_unique_preset_name(presets, base_name):
@@ -28,5 +28,4 @@ def check_preset_version(preset):
     preset_version = (0, 0, 0)
     if "version" in preset:
         preset_version = tuple(preset["version"])
-    current_version = bl_info["version"]
-    return preset_version >= current_version
+    return preset_version >= PRESETS_VERSION

--- a/presets/version.py
+++ b/presets/version.py
@@ -1,0 +1,1 @@
+PRESETS_VERSION = (2026, 4, 0)


### PR DESCRIPTION
- **Fix**: Presets saved on 2026.4 could not be called in 2026.5.
- **Fix** (#347): Smart Check for Custom Properties not working properly with Shape Keys.
- **Fix** (#350): Hair Curves not shown in the Hair panel (by @Ckang3D).
- **FIx** (#352): Collection visibility cascade hides nested hair sub-collections on outfit switch (by @Ckang3D).