### PR TITLE
 feat: drag-toggle outfit/hair visibility, hair switcher cascade fix, single object hair toggles

### DIFF
--- a/hair/ops_hair_visibility.py
+++ b/hair/ops_hair_visibility.py
@@ -27,6 +27,50 @@ def set_object_visibility(obj, visible, rig_settings):
             )
 
 
+def update_hair_extras_collection_visibility(hair_extras_collection):
+    # Sync the collection visibility with the objects visibility
+    hidden = all(x.hide_viewport for x in hair_extras_collection.objects)
+    hair_extras_collection.hide_viewport = hidden
+    hair_extras_collection.hide_render = hidden
+
+
+def set_hair_extra_visibility(context, obj, visible):
+    # Shared visibility update used by both the operator and the UI toggle
+    poll, arm = mustardui_active_object(context, config=0)
+    if not poll:
+        return False
+
+    rig_settings = arm.MustardUI_RigSettings
+    hair_extras_collection = rig_settings.hair_extras_collection
+    if not hair_extras_collection:
+        return False
+
+    extra_objects = [x for x in hair_extras_collection.objects if obj.name == x.name]
+    if len(extra_objects) == 0:
+        return False
+
+    for extra_obj in extra_objects:
+        set_object_visibility(extra_obj, visible, rig_settings)
+
+    update_hair_extras_collection_visibility(hair_extras_collection)
+
+    outfits_update_armature_collections(rig_settings, arm)
+
+    if rig_settings.hair_update_tag_on_switch:
+        for extra_obj in hair_extras_collection.objects:
+            extra_obj.update_tag()
+
+    return True
+
+
+def get_hair_extra_visibility(obj):
+    return not obj.hide_viewport
+
+
+def set_hair_extra_visibility_prop(obj, value):
+    set_hair_extra_visibility(bpy.context, obj, value)
+
+
 class MustardUI_HairVisibility(bpy.types.Operator):
     """Switch visibility of hair objects in a collection"""
 
@@ -72,7 +116,13 @@ class MustardUI_HairVisibility(bpy.types.Operator):
 
 
 class MustardUI_HairVisibility_Extras(bpy.types.Operator):
-    """Switch visibility of hair objects in a collection"""
+    """Switch visibility of hair objects in a collection.
+
+    Note: the in-panel UI no longer invokes this operator (it uses the
+    ``MustardUI_hair_extra_visibility`` BoolProperty on Object so that
+    drag-toggle works). This operator is kept as a public API entry
+    point for keymaps and external scripts referencing ``bl_idname``.
+    """
 
     bl_idname = "mustardui.hair_visibility_extras"
     bl_label = "Hair Visibility Extras"
@@ -101,24 +151,7 @@ class MustardUI_HairVisibility_Extras(bpy.types.Operator):
         obj = context.scene.objects[hair_name]
         visibility = obj.hide_viewport
 
-        # Loop through hair objects
-        for obj in [x for x in hair_extras_collection.objects if hair_name == x.name]:
-            set_object_visibility(obj, visibility, rig_settings)
-
-        if all(x.hide_viewport for x in hair_extras_collection.objects):
-            hair_extras_collection.hide_viewport = True
-            hair_extras_collection.hide_render = True
-        else:
-            hair_extras_collection.hide_viewport = False
-            hair_extras_collection.hide_render = False
-
-        # Update armature collections visibility using the outfit-style logic
-        outfits_update_armature_collections(rig_settings, arm)
-
-        # Update tags if enabled
-        if rig_settings.hair_update_tag_on_switch:
-            for obj in hair_extras_collection.objects:
-                obj.update_tag()
+        set_hair_extra_visibility(context, obj, visibility)
 
         return {"FINISHED"}
 
@@ -151,6 +184,14 @@ class MustardUI_HairVisibility_Extras_ParticleSystem(bpy.types.Operator):
 
 
 def register():
+    # Bool property used to enable drag-toggle interactions in the UI
+    bpy.types.Object.MustardUI_hair_extra_visibility = bpy.props.BoolProperty(
+        default=False,
+        name="",
+        description="Toggle Hair Extra visibility",
+        get=get_hair_extra_visibility,
+        set=set_hair_extra_visibility_prop,
+    )
     bpy.utils.register_class(MustardUI_HairVisibility)
     bpy.utils.register_class(MustardUI_HairVisibility_Extras)
     bpy.utils.register_class(MustardUI_HairVisibility_Extras_ParticleSystem)
@@ -160,3 +201,4 @@ def unregister():
     bpy.utils.unregister_class(MustardUI_HairVisibility_Extras_ParticleSystem)
     bpy.utils.unregister_class(MustardUI_HairVisibility_Extras)
     bpy.utils.unregister_class(MustardUI_HairVisibility)
+    del bpy.types.Object.MustardUI_hair_extra_visibility

--- a/hair/ops_hair_visibility.py
+++ b/hair/ops_hair_visibility.py
@@ -71,6 +71,51 @@ def set_hair_extra_visibility_prop(obj, value):
     set_hair_extra_visibility(bpy.context, obj, value)
 
 
+def _apply_visibility_to_main_hair(rig_settings, predicate):
+    # Iterates direct children of hair_collection only — nested
+    # sub-collections (hair_extras_collection, hair_switch_collection) are
+    # intentionally untouched so users who organise them under hair_collection
+    # in the outliner aren't dragged into cascade-hides.
+    hair_collection = rig_settings.hair_collection
+    if hair_collection is None:
+        return
+
+    hair_objs = list(hair_collection.objects)
+    for obj in hair_objs:
+        if obj.type not in {"MESH", "CURVES"}:
+            continue
+        visible = predicate(obj.name)
+        set_object_visibility(obj, visible, rig_settings)
+        parent_armature = obj.find_armature()
+        if parent_armature is not None and parent_armature in hair_objs:
+            set_object_visibility(parent_armature, visible, rig_settings)
+
+    if rig_settings.hair_update_tag_on_switch:
+        for obj in hair_collection.objects:
+            obj.update_tag()
+
+
+def hide_all_main_hair(rig_settings):
+    """Hide every main-hair piece in hair_collection (direct children only).
+
+    Used by the outfit code when an outfit piece linked into
+    ``hair_switch_collection`` becomes visible: the main hair gets out of the
+    way without cascade-hiding any nested sub-collections.
+    """
+    _apply_visibility_to_main_hair(rig_settings, lambda _name: False)
+
+
+def apply_hair_list_visibility(rig_settings):
+    """Restore main-hair visibility per ``rig_settings.hair_list`` selection.
+
+    Used by the outfit code when a hair-switching piece becomes hidden, to
+    bring back the currently selected hair (matches the semantics of the
+    ``mustardui.hair_visibility`` operator).
+    """
+    hair_list = rig_settings.hair_list
+    _apply_visibility_to_main_hair(rig_settings, lambda name: name == hair_list)
+
+
 class MustardUI_HairVisibility(bpy.types.Operator):
     """Switch visibility of hair objects in a collection"""
 

--- a/menu/menu_hair.py
+++ b/menu/menu_hair.py
@@ -29,17 +29,17 @@ def draw_hair_piece(layout, obj, arm, rig_settings, physics_settings, settings):
     col = layout.column()
     row = col.row(align=True)
 
-    op = row.operator(
-        "mustardui.hair_visibility_extras",
+    row.prop(
+        obj,
+        "MustardUI_hair_extra_visibility",
         text=strip_naming_convention(
             obj.name,
             rig_settings.hair_extras_collection.name,
             rig_settings.model_MustardUI_naming_convention,
         ),
         icon="OUTLINER_OB_" + obj.type,
-        depress=not obj.hide_viewport,
+        toggle=True,
     )
-    op.obj_name = obj.name
 
     # Physics
     pi = None

--- a/menu/menu_outfits.py
+++ b/menu/menu_outfits.py
@@ -53,19 +53,31 @@ def draw_outfit_piece(
         nname = obj.name[len(re.sub(r"\.\d{3}", "", coll_name)) :]
         nname = re.sub(r"\.\d{3}", "", nname)
 
-        row.operator(
-            "mustardui.object_visibility",
+        row.prop(
+            obj,
+            "MustardUI_outfit_toggle_visibility",
             text=nname,
             icon="OUTLINER_OB_" + obj.type,
-            depress=not obj.hide_viewport,
-        ).obj = obj.name
+            toggle=True,
+        )
     else:
-        row.operator(
-            "mustardui.object_visibility",
+        row.prop(
+            obj,
+            "MustardUI_outfit_toggle_visibility",
             text=obj.name,
             icon="OUTLINER_OB_" + obj.type,
-            depress=not obj.hide_viewport,
-        ).obj = obj.name
+            toggle=True,
+        )
+
+    # Toggle self + children together (replaces the old shift+click behaviour)
+    if obj.children:
+        op = row.operator(
+            "mustardui.object_visibility",
+            text="",
+            icon="LINKED",
+        )
+        op.obj = obj.name
+        op.shift = True
 
     # Physics
     pi = None

--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -6,6 +6,163 @@ from ..physics.update_enable import enable_physics_update
 from .helper_functions import outfits_update_armature_collections
 
 
+def set_outfit_visibility(context, obj, desired_visible, include_children=False):
+    # Shared visibility update used by both the operator and the UI toggle
+    poll, arm = mustardui_active_object(context, config=0)
+    if not poll:
+        return False
+
+    rig_settings = arm.MustardUI_RigSettings
+    armature_settings = arm.MustardUI_ArmatureSettings
+    physics_settings = arm.MustardUI_PhysicsSettings
+    outfit_cp = arm.MustardUI_CustomPropertiesOutfit
+
+    hair_collection = rig_settings.hair_collection
+    hair_switch_collection = rig_settings.hair_switch_collection
+
+    def apply_visibility(o, visible):
+        hidden = not visible
+
+        # Object visibility
+        set_bool(o, "hide_viewport", hidden)
+        set_bool(o, "hide_render", hidden)
+        set_bool(o, "MustardUI_outfit_visibility", hidden)
+
+        # Shape Keys and their drivers
+        if (
+            rig_settings.outfit_switch_shape_keys_disable
+            and o.type == "MESH"
+            and o.data
+            and o.data.shape_keys
+        ):
+            for key in o.data.shape_keys.key_blocks:
+                set_bool(key, "mute", hidden)
+            if o.data.shape_keys.animation_data and o.data.shape_keys.animation_data.drivers:
+                for fcurve in o.data.shape_keys.animation_data.drivers:
+                    set_bool(fcurve, "mute", hidden)
+
+        if (
+            rig_settings.outfit_switch_armature_disable
+            or rig_settings.outfit_switch_modifiers_disable
+        ):
+            for mod in o.modifiers:
+                if (
+                    mod.type == "ARMATURE"
+                    and rig_settings.outfit_switch_armature_disable
+                ):
+                    set_bool(mod, "show_viewport", visible)
+                    continue
+
+                if not rig_settings.outfit_switch_modifiers_disable:
+                    continue
+
+                if (
+                    mod.type == "CORRECTIVE_SMOOTH"
+                    and rig_settings.outfits_enable_global_smoothcorrection
+                ):
+                    desired = visible if rig_settings.outfits_global_smoothcorrection else False
+                    set_bool(mod, "show_viewport", desired)
+                elif (
+                    mod.type == "SHRINKWRAP"
+                    and rig_settings.outfits_enable_global_shrinkwrap
+                ):
+                    desired = visible if rig_settings.outfits_global_shrinkwrap else False
+                    set_bool(mod, "show_viewport", desired)
+                elif (
+                    mod.type == "SUBSURF"
+                    and rig_settings.outfits_enable_global_subsurface
+                ):
+                    desired = visible if rig_settings.outfits_global_subsurface else False
+                    set_bool(mod, "show_viewport", desired)
+
+        # Hair visibility
+        if (
+            hair_collection is not None
+            and o.type in ["MESH", "ARMATURE"]
+            and hair_switch_collection is not None
+            and o.name in hair_switch_collection.all_objects.keys()
+        ):
+            hair_collection.hide_viewport = visible
+            hair_collection.hide_render = visible
+
+        # Custom properties
+        ui_data_cache = {}
+        for cp in outfit_cp:
+            if cp.outfit_piece != o:
+                continue
+            if not (cp.outfit_enable_on_switch or cp.outfit_disable_on_switch):
+                continue
+
+            prop = cp.prop_name
+            ui_data = ui_data_cache.get(prop)
+            if ui_data is None:
+                ui_data = arm.id_properties_ui(prop).as_dict()
+                ui_data_cache[prop] = ui_data
+
+            if visible and cp.outfit_enable_on_switch:
+                if arm[prop] != ui_data["max"]:
+                    arm[prop] = ui_data["max"]
+            elif hidden and cp.outfit_disable_on_switch:
+                if arm[prop] != ui_data["default"]:
+                    arm[prop] = ui_data["default"]
+
+        # Body mask modifiers
+        body = rig_settings.model_body
+        if body:
+            for mod in body.modifiers:
+                if (
+                    mod.type in ["MASK", "VERTEX_WEIGHT_MIX"]
+                    and obj.name in mod.name.split("|")
+                    and rig_settings.outfits_global_mask
+                ):
+                    set_bool(mod, "show_viewport", visible)
+                    set_bool(mod, "show_render", visible)
+
+    apply_visibility(obj, desired_visible)
+
+    if include_children:
+        # Apply to children if requested by the operator
+        for child in obj.children:
+            if (not child.hide_viewport) != desired_visible:
+                apply_visibility(child, desired_visible)
+
+    # Physics update
+    if physics_settings.enable_ui:
+        enable_physics_update(physics_settings, context)
+
+    # Update tags
+    if rig_settings.outfits_update_tag_on_switch:
+        arm.update_tag()
+        obj.update_tag()
+        for child in obj.children:
+            child.update_tag()
+
+    # Extras collection visibility
+    extras = rig_settings.extras_collection
+    hidden = None
+    if extras:
+        items = (
+            extras.all_objects if rig_settings.outfit_config_subcollections else extras.objects
+        )
+        hidden = all(x.hide_render for x in items)
+        set_bool(extras, "hide_viewport", hidden)
+        set_bool(extras, "hide_render", hidden)
+
+    # Armature collections
+    if armature_settings.outfits:
+        outfits_update_armature_collections(rig_settings, arm, is_extras_hidden=hidden)
+
+    return True
+
+
+def get_outfit_toggle_visibility(obj):
+    return not obj.hide_viewport
+
+
+def set_outfit_toggle_visibility(obj, value):
+    set_outfit_visibility(bpy.context, obj, value)
+
+
 class MustardUI_OutfitVisibility(bpy.types.Operator):
     """Change the visibility of the selected object"""
 
@@ -29,172 +186,14 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
             self.report({"WARNING"}, f'MustardUI - Object "{self.obj}" not found.')
             return {"CANCELLED"}
 
+        set_outfit_visibility(context, obj, obj.hide_viewport, include_children=self.shift)
+
+        # Body is required for the body-mask sync inside set_outfit_visibility;
+        # warn once per click if it is missing (was reported per-object in the old code).
         poll, arm = mustardui_active_object(context, config=0)
-        rig_settings = arm.MustardUI_RigSettings
-        armature_settings = arm.MustardUI_ArmatureSettings
-        physics_settings = arm.MustardUI_PhysicsSettings
-        outfit_cp = arm.MustardUI_CustomPropertiesOutfit
-
-        hair_collection = rig_settings.hair_collection
-        hair_switch_collection = rig_settings.hair_switch_collection
-
-        # ------------------- PER-OBJECT UPDATES ------------------- #
-        def apply_visibility(o):
-            # Object visibility
-            visible = not o.hide_viewport
-
-            set_bool(o, "hide_viewport", visible)
-            set_bool(o, "hide_render", visible)
-            set_bool(o, "MustardUI_outfit_visibility", visible)
-
-            # Shape Keys and their drivers
-            if (
-                rig_settings.outfit_switch_shape_keys_disable
-                and obj.type == "MESH"
-                and obj.data
-                and obj.data.shape_keys
-            ):
-                for key in obj.data.shape_keys.key_blocks:
-                    set_bool(key, "mute", visible)
-                if (
-                    obj.data.shape_keys.animation_data
-                    and obj.data.shape_keys.animation_data.drivers
-                ):
-                    for fcurve in obj.data.shape_keys.animation_data.drivers:
-                        set_bool(fcurve, "mute", visible)
-
-            # Modifier visibility
-            if (
-                rig_settings.outfit_switch_armature_disable
-                or rig_settings.outfit_switch_modifiers_disable
-            ):
-                for mod in o.modifiers:
-                    if (
-                        mod.type == "ARMATURE"
-                        and rig_settings.outfit_switch_armature_disable
-                    ):
-                        set_bool(mod, "show_viewport", not visible)
-                        continue
-
-                    if not rig_settings.outfit_switch_modifiers_disable:
-                        continue
-
-                    if (
-                        mod.type == "CORRECTIVE_SMOOTH"
-                        and rig_settings.outfits_enable_global_smoothcorrection
-                    ):
-                        desired = (
-                            not visible
-                            if rig_settings.outfits_global_smoothcorrection
-                            else False
-                        )
-                        set_bool(mod, "show_viewport", desired)
-                    elif (
-                        mod.type == "SHRINKWRAP"
-                        and rig_settings.outfits_enable_global_shrinkwrap
-                    ):
-                        desired = (
-                            not visible
-                            if rig_settings.outfits_global_shrinkwrap
-                            else False
-                        )
-                        set_bool(mod, "show_viewport", desired)
-                    elif (
-                        mod.type == "SUBSURF"
-                        and rig_settings.outfits_enable_global_subsurface
-                    ):
-                        desired = (
-                            not visible
-                            if rig_settings.outfits_global_subsurface
-                            else False
-                        )
-                        set_bool(mod, "show_viewport", desired)
-
-            # Hair visibility
-            if (
-                hair_collection is not None
-                and o.type in ["MESH", "ARMATURE"]
-                and hair_switch_collection is not None
-                and o.name in hair_switch_collection.all_objects.keys()
-            ):
-                hair_collection.hide_viewport = not visible
-                hair_collection.hide_render = not visible
-
-            # Custom properties
-            ui_data_cache = {}
-            for cp in outfit_cp:
-                if cp.outfit_piece != o:
-                    continue
-                if not (cp.outfit_enable_on_switch or cp.outfit_disable_on_switch):
-                    continue
-
-                prop = cp.prop_name
-                ui_data = ui_data_cache.get(prop)
-                if ui_data is None:
-                    ui_data = arm.id_properties_ui(prop).as_dict()
-                    ui_data_cache[prop] = ui_data
-
-                if not visible and cp.outfit_enable_on_switch:
-                    if arm[prop] != ui_data["max"]:
-                        arm[prop] = ui_data["max"]
-                elif visible and cp.outfit_disable_on_switch:
-                    if arm[prop] != ui_data["default"]:
-                        arm[prop] = ui_data["default"]
-
-            # Body mask modifiers
-            body = rig_settings.model_body
-            if body:
-                for mod in body.modifiers:
-                    if (
-                        mod.type in ["MASK", "VERTEX_WEIGHT_MIX"]
-                        and self.obj in mod.name.split("|")
-                        and rig_settings.outfits_global_mask
-                    ):
-                        set_bool(mod, "show_viewport", not o.hide_viewport)
-                        set_bool(mod, "show_render", not o.hide_viewport)
-            else:
-                self.report(
-                    {"WARNING"}, "MustardUI - Outfit Body has not been specified."
-                )
-
-        # Apply to main object
-        apply_visibility(obj)
-
-        # Apply to children if shift is pressed
-        if self.shift:
-            for child in obj.children:
-                if child.hide_viewport != obj.hide_viewport:
-                    apply_visibility(child)
-
-        # ------------------- GLOBAL UPDATES ------------------- #
-        # Physics update
-        if physics_settings.enable_ui:
-            enable_physics_update(physics_settings, context)
-
-        # Update tags
-        if rig_settings.outfits_update_tag_on_switch:
-            arm.update_tag()
-            obj.update_tag()
-            for child in obj.children:
-                child.update_tag()
-
-        # Extras collection visibility
-        extras = rig_settings.extras_collection
-        hidden = None
-        if extras:
-            items = (
-                extras.all_objects
-                if rig_settings.outfit_config_subcollections
-                else extras.objects
-            )
-            hidden = all(x.hide_render for x in items)
-            set_bool(extras, "hide_viewport", hidden)
-            set_bool(extras, "hide_render", hidden)
-
-        # Armature collections
-        if armature_settings.outfits:
-            outfits_update_armature_collections(
-                rig_settings, arm, is_extras_hidden=hidden
+        if poll and not arm.MustardUI_RigSettings.model_body:
+            self.report(
+                {"WARNING"}, "MustardUI - Outfit Body has not been specified."
             )
 
         self.shift = False
@@ -202,8 +201,17 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
 
 
 def register():
+    # Bool property used to enable drag-toggle interactions in the UI
+    bpy.types.Object.MustardUI_outfit_toggle_visibility = bpy.props.BoolProperty(
+        default=False,
+        name="",
+        description="Toggle Outfit visibility",
+        get=get_outfit_toggle_visibility,
+        set=set_outfit_toggle_visibility,
+    )
     bpy.utils.register_class(MustardUI_OutfitVisibility)
 
 
 def unregister():
     bpy.utils.unregister_class(MustardUI_OutfitVisibility)
+    del bpy.types.Object.MustardUI_outfit_toggle_visibility

--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -7,6 +7,14 @@ from .helper_functions import outfits_update_armature_collections
 
 
 def set_outfit_visibility(context, obj, desired_visible, include_children=False):
+    # Lazy import: hair.ops_hair_visibility itself imports from
+    # outfits.helper_functions, so importing it at module top-level would
+    # create a circular import when the outfits package is being initialised.
+    from ..hair.ops_hair_visibility import (
+        apply_hair_list_visibility,
+        hide_all_main_hair,
+    )
+
     # Shared visibility update used by both the operator and the UI toggle
     poll, arm = mustardui_active_object(context, config=0)
     if not poll:
@@ -75,15 +83,20 @@ def set_outfit_visibility(context, obj, desired_visible, include_children=False)
                     desired = visible if rig_settings.outfits_global_subsurface else False
                     set_bool(mod, "show_viewport", desired)
 
-        # Hair visibility
+        # Hair visibility (when this outfit piece doubles as a hair switcher).
+        # Toggle main-hair pieces individually rather than the whole
+        # hair_collection, so nested sub-collections (extras, switcher) aren't
+        # cascade-hidden by Blender's collection visibility.
         if (
             hair_collection is not None
             and o.type in ["MESH", "ARMATURE"]
             and hair_switch_collection is not None
             and o.name in hair_switch_collection.all_objects.keys()
         ):
-            hair_collection.hide_viewport = visible
-            hair_collection.hide_render = visible
+            if visible:
+                hide_all_main_hair(rig_settings)
+            else:
+                apply_hair_list_visibility(rig_settings)
 
         # Custom properties
         ui_data_cache = {}

--- a/outfits/ops_visibility_full.py
+++ b/outfits/ops_visibility_full.py
@@ -18,6 +18,13 @@ class MustardUI_CompleteOutfitVisibility(bpy.types.Operator):
     bl_options = {"UNDO"}
 
     def execute(self, context):
+        # Lazy import: hair.ops_hair_visibility itself imports from
+        # outfits.helper_functions, so importing it at module top-level
+        # would create a circular import during package initialisation.
+        from ..hair.ops_hair_visibility import (
+            apply_hair_list_visibility,
+            hide_all_main_hair,
+        )
 
         poll, arm = mustardui_active_object(context, config=0)
         if not poll:
@@ -52,7 +59,14 @@ class MustardUI_CompleteOutfitVisibility(bpy.types.Operator):
         mask = rig_settings.outfits_global_mask
 
         # Collections, objects, modifiers, masks
-        hair_switcher_set = False
+        # ``hair_switcher_seen`` tracks whether any iterated outfit object
+        # was linked into hair_switch_collection; ``hair_switcher_active``
+        # records whether any of those was visible. We act on hair_collection
+        # only after all outfits are processed, individually toggling main
+        # hair pieces (not the collection itself) so nested sub-collections
+        # like hair_extras_collection aren't cascade-hidden.
+        hair_switcher_seen = False
+        hair_switcher_active = False
 
         for col_entry in rig_settings.outfits_collections:
             col = col_entry.collection
@@ -96,23 +110,19 @@ class MustardUI_CompleteOutfitVisibility(bpy.types.Operator):
                 set_bool(obj, "hide_viewport", not show_obj)
                 set_bool(obj, "hide_render", not show_obj)
 
-                # Check Hair Visibility against the Hair Switcher Collection
-                hair_collection = rig_settings.hair_collection
+                # Check Hair Visibility against the Hair Switcher Collection.
+                # Only collect flags here; the actual hair toggle happens
+                # once after all outfits have been processed.
                 if (
-                    hair_collection is not None
+                    rig_settings.hair_collection is not None
                     and obj.type in ["MESH", "ARMATURE"]
                     and rig_settings.hair_switch_collection is not None
                     and obj.name
                     in rig_settings.hair_switch_collection.all_objects.keys()
                 ):
+                    hair_switcher_seen = True
                     if show_obj:
-                        hair_switcher_set = True
-                    set_bool(
-                        hair_collection, "hide_viewport", show_obj or hair_switcher_set
-                    )
-                    set_bool(
-                        hair_collection, "hide_render", show_obj or hair_switcher_set
-                    )
+                        hair_switcher_active = True
 
                 if show_obj:
                     any_object_visible = True
@@ -180,6 +190,14 @@ class MustardUI_CompleteOutfitVisibility(bpy.types.Operator):
             col_visible = is_active or locked_collection or any_object_visible
             set_bool(col, "hide_viewport", not col_visible)
             set_bool(col, "hide_render", not col_visible)
+
+        # Apply hair switching once, per-piece (preserves nested
+        # extras/switcher sub-collections under hair_collection).
+        if hair_switcher_seen:
+            if hair_switcher_active:
+                hide_all_main_hair(rig_settings)
+            else:
+                apply_hair_list_visibility(rig_settings)
 
         # Armature layers
         if arm_settings.outfits:


### PR DESCRIPTION
## Changes

  - Replace per-piece visibility operator buttons with BoolProperty toggles (drag-toggle support)
  - Add single object main hair viewport/render visibility controls
  - Add persistent link_children_visibility toggle
  - **Fix #352**: hair switcher no longer cascade-hides nested hair sub-collections