### PR TITLE
Version 2026.5.3

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: "pip"

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -35,7 +35,7 @@ jobs:
 
     name: Blender ${{ matrix.blender }}
     needs: lint
-    uses: Mustard2/blender-workflows/.github/workflows/blender-build.yml@v3
+    uses: Mustard2/blender-workflows/.github/workflows/blender-build.yml@v4
     with:
       timeout-seconds: 180
       blender-version: ${{ matrix.blender }}

--- a/__init__.py
+++ b/__init__.py
@@ -6,7 +6,7 @@ bl_info = {
     "name": "MustardUI",
     "description": "Easy-to-use UI for human characters.",
     "author": "Mustard",
-    "version": (2026, 5, 2),
+    "version": (2026, 5, 3),
     "blender": (4, 2, 0),
     "warning": "",
     "doc_url": "https://github.com/Mustard2/MustardUI/wiki",

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "MustardUI"
-version = "2026.5.2"
+version = "2026.5.3"
 name = "MustardUI"
 tagline = "Easy-to-use UI for human characters"
 maintainer = "Mustard"

--- a/custom_properties/misc.py
+++ b/custom_properties/misc.py
@@ -171,6 +171,18 @@ def mustardui_cp_path(rna, path):
 
 
 def assign_ptr(custom_prop, rna, addon_prefs):
+    # Skip assignment if already assigned
+    # This is to avoid to overwrite the custom property type to "None"
+    if custom_prop.ptr_type != "None" and (
+        custom_prop.ptr_armature is not None
+        or custom_prop.ptr_object is not None
+        or custom_prop.ptr_key is not None
+        or custom_prop.ptr_material is not None
+        or custom_prop.ptr_collection is not None
+        or custom_prop.ptr_node_tree is not None
+    ):
+        return
+
     # Get the type and assign the pointer
     try:
         if "bpy.data.armatures" in rna and custom_prop.ptr_armature is None:

--- a/custom_properties/ops_rebuild.py
+++ b/custom_properties/ops_rebuild.py
@@ -477,7 +477,9 @@ class MustardUI_Property_Rebuild(bpy.types.Operator):
                     "infos.",
                 )
         else:
-            self.report({"INFO"}, "MustardUI - Custom Properties rebuilt.")
+            self.report(
+                {"INFO"}, "MustardUI - All Custom Properties successfully rebuilt."
+            )
 
         return {"FINISHED"}
 

--- a/menu/menu_tools_creators.py
+++ b/menu/menu_tools_creators.py
@@ -211,15 +211,47 @@ class PANEL_PT_MustardUI_ToolsCreators_Physics(MainPanel, bpy.types.Panel):
         )
 
 
+class PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup(MainPanel, bpy.types.Panel):
+    bl_parent_id = "PANEL_PT_MustardUI_ToolsCreators"
+    bl_label = "Optimize & Clean-up"
+    bl_options = {"DEFAULT_CLOSED"}
+
+    @classmethod
+    def poll(cls, context):
+        if can_draw_ui():
+            return False
+
+        res, arm = mustardui_active_object(context, config=1)
+        addon_prefs = context.preferences.addons[base_package].preferences
+        settings = bpy.context.scene.MustardUI_Settings
+        return res and addon_prefs.developer and not settings.viewport_model_selection
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(text="", icon="FORCE_WIND")
+
+    def draw(self, context):
+
+        layout = self.layout
+
+        row = layout.row(align=True)
+        row.operator(
+            "mustardui.tools_creators_optimize_modifiers",
+            icon="MOD_SMOOTH",
+        )
+
+
 def register():
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Model)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Rig)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Mesh)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Physics)
+    bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup)
 
 
 def unregister():
+    bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Physics)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Mesh)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Rig)

--- a/menu/menu_tools_creators.py
+++ b/menu/menu_tools_creators.py
@@ -211,9 +211,9 @@ class PANEL_PT_MustardUI_ToolsCreators_Physics(MainPanel, bpy.types.Panel):
         )
 
 
-class PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup(MainPanel, bpy.types.Panel):
+class PANEL_PT_MustardUI_ToolsCreators_Optimizations(MainPanel, bpy.types.Panel):
     bl_parent_id = "PANEL_PT_MustardUI_ToolsCreators"
-    bl_label = "Optimize & Clean-up"
+    bl_label = "Optimizations"
     bl_options = {"DEFAULT_CLOSED"}
 
     @classmethod
@@ -247,11 +247,11 @@ def register():
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Rig)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Mesh)
     bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Physics)
-    bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup)
+    bpy.utils.register_class(PANEL_PT_MustardUI_ToolsCreators_Optimizations)
 
 
 def unregister():
-    bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_OptimizeCleanup)
+    bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Optimizations)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Physics)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Mesh)
     bpy.utils.unregister_class(PANEL_PT_MustardUI_ToolsCreators_Rig)

--- a/morphs/ops_defvalue.py
+++ b/morphs/ops_defvalue.py
@@ -51,7 +51,12 @@ class MustardUI_DazMorphs_DefaultValues(bpy.types.Operator):
                 break
         # Apply the preset
         if preset_default > -1:
-            bpy.ops.mustardui.morphs_preset_apply()
+            # Override the selected preset
+            arm.mustardui_morphs_preset_uilist_index = preset_default
+            # Set the preset
+            bpy.ops.mustardui.preset_apply(
+                preset_type="MORPHS", force_modifiers_creation=False
+            )
 
         # Update everything
         if arm:

--- a/tools_creators/__init__.py
+++ b/tools_creators/__init__.py
@@ -10,6 +10,7 @@ from . import (
     ops_jiggle,
     ops_link_shape_keys,
     ops_naming,
+    ops_optimize_mods,
     ops_pack_rgba,
     ops_rename,
     ops_rename_images,
@@ -36,9 +37,11 @@ def register():
     ops_link_shape_keys.register()
     ops_transfer_vertex_groups.register()
     ops_pack_rgba.register()
+    ops_optimize_mods.register()
 
 
 def unregister():
+    ops_optimize_mods.unregister()
     ops_pack_rgba.unregister()
     ops_transfer_vertex_groups.unregister()
     ops_link_shape_keys.unregister()

--- a/tools_creators/ops_optimize_mods.py
+++ b/tools_creators/ops_optimize_mods.py
@@ -239,11 +239,10 @@ class MustardUI_ToolsCreators_OptimizeModifiers(bpy.types.Operator):
         col.prop(self, "mask", icon="MOD_MASK")
         col.prop(self, "smooth_corrective", icon="MOD_SMOOTH")
 
-        box = layout.box()
-        box.label(text="Settings", icon="PREFERENCES")
-        col = box.column(align=True)
-        col.prop(self, "preserve_modifiers")
+        layout.separator()
 
+        col = layout.column(align=True)
+        col.prop(self, "preserve_modifiers")
         row = col.row()
         row.enabled = self.smooth_corrective
         row.prop(self, "sm_influence")

--- a/tools_creators/ops_optimize_mods.py
+++ b/tools_creators/ops_optimize_mods.py
@@ -1,0 +1,257 @@
+import bpy
+
+sm_vg_name = "MustardUI - Smooth Corrective"
+mask_vg_name = "MustardUI - Mask"
+
+
+def add_corrective_smooth_modifier(
+    obj, group_name=None, name="", iterations=20, smooth_type="SIMPLE"
+):
+    # Add a Corrective Smooth modifier with specified settings
+    mod = obj.modifiers.new(name=name, type="CORRECTIVE_SMOOTH")
+    mod.iterations = iterations
+    mod.smooth_type = smooth_type
+    mod.rest_source = "BIND"
+    if group_name:
+        mod.vertex_group = group_name
+    bpy.context.view_layer.objects.active = obj
+    bpy.ops.object.correctivesmooth_bind(modifier=mod.name)
+    return mod
+
+
+def add_mask_modifier(obj, group_name=None, name=""):
+    # Add a Corrective Smooth modifier with specified settings
+    mod = obj.modifiers.new(name=name, type="MASK")
+    mod.invert_vertex_group = True
+    if group_name:
+        mod.vertex_group = group_name
+    return mod
+
+
+def get_index(obj, name):
+    return next(
+        (i for i, m in enumerate(obj.modifiers) if m.name == name),
+        len(obj.modifiers),
+    )
+
+
+def optimize_modifiers(
+    context, obj, mod_type, mod_vg_name, sm_influence=True, preserve_modifiers=True
+):
+    arm = None
+    pose_position = None
+    for mod in obj.modifiers:
+        if mod.type == "ARMATURE":
+            arm = (
+                mod.object.data
+                if mod.object is not None and mod.object.data is not None
+                else None
+            )
+    if arm is not None:
+        pose_position = arm.pose_position
+        arm.pose_position = "REST"
+
+    if mod_vg_name not in obj.vertex_groups:
+        obj.vertex_groups.new(name=mod_vg_name)
+
+    # Temporarily set body as active for modifier_move_to_index
+    prev_active = context.view_layer.objects.active
+    context.view_layer.objects.active = obj
+
+    mods = []
+    max_iterations = 0
+    lst_index = 0
+    for mod in list(obj.modifiers):
+        if not mod.type == mod_type:
+            continue
+
+        iterations = 0
+        scale = 0
+
+        if mod.vertex_group == "" or mod.vertex_group == mod_vg_name:
+            continue
+        name = mod.name
+        vg = mod.vertex_group
+        if mod_type == "CORRECTIVE_SMOOTH":
+            iterations = mod.iterations
+            scale = mod.scale
+        visibility = mod.show_viewport
+        lst_index = get_index(obj, name)
+
+        if not preserve_modifiers:
+            obj.modifiers.remove(mod)
+        else:
+            mod.show_viewport = False
+            mod.show_render = False
+            mod.name = mod.name + "Disabled"
+
+        mod = obj.modifiers.new(name=name, type="VERTEX_WEIGHT_MIX")
+        mod.vertex_group_a = mod_vg_name
+        mod.vertex_group_b = vg
+        mod.mix_set = "ALL"
+        mod.mix_mode = "ADD"
+        mod.show_expanded = False
+
+        mods.append((mod, iterations, scale))
+        max_iterations = max(max_iterations, iterations)
+
+        mod.show_viewport = visibility
+        mod.show_render = visibility
+
+        bpy.ops.object.modifier_move_to_index(
+            modifier=mod.name,
+            index=lst_index,
+        )
+
+    if len(mods) < 1:
+        return 0, "No Modifier to convert"
+
+    if mod_type == "CORRECTIVE_SMOOTH" and sm_influence and max_iterations > 0:
+        for mod, iterations, scale in [x for x in mods if x is not None]:
+            mod.mask_constant = 1.0 * float(iterations) / float(max_iterations)
+            mod.mask_constant *= scale
+
+    master_mod = next(
+        (m for m in obj.modifiers if m.type == mod_type and m.name == mod_vg_name),
+        None,
+    )
+    if master_mod is not None:
+        obj.modifiers.remove(master_mod)
+
+    if mod_type == "CORRECTIVE_SMOOTH":
+        master_mod = add_corrective_smooth_modifier(
+            obj,
+            mod_vg_name,
+            mod_vg_name,
+            iterations=max_iterations,
+            smooth_type="SIMPLE",
+        )
+    else:
+        master_mod = add_mask_modifier(obj, mod_vg_name, mod_vg_name)
+
+    if master_mod is None:
+        master_mod.show_expanded = False
+    bpy.ops.object.modifier_move_to_index(
+        modifier=master_mod.name,
+        index=lst_index + 1,
+    )
+
+    context.view_layer.objects.active = prev_active
+    if arm is not None and pose_position is not None:
+        arm.pose_position = pose_position
+
+    return len(mods)
+
+
+class MustardUI_ToolsCreators_OptimizeModifiers(bpy.types.Operator):
+    """Optimize the Smooth Corrective modifiers on the Active Object.\nCreates a unique Smooth Corrective modifier and use the Vertex Weight Mix modifiers to generate the Vertex Group"""  # noqa: E501
+
+    bl_idname = "mustardui.tools_creators_optimize_modifiers"
+    bl_label = "Optimize Modifiers"
+    bl_options = {"UNDO"}
+
+    sm_influence: bpy.props.BoolProperty(
+        default=True,
+        name="Set Vertex Groups Influence",
+        description="Use the Iterations number and the Scale settings of the Smooth "
+        "Modifier settings to set the Vertex Mix Modifiers influence "
+        "to preserve relative strength of the correction",
+    )
+
+    preserve_modifiers: bpy.props.BoolProperty(
+        default=False,
+        name="Preserve Smooth Corrective modifiers",
+        description="Disable existent Smooth Corrective modifiers instead "
+        "of removing them",
+    )
+
+    smooth_corrective: bpy.props.BoolProperty(
+        default=True,
+        name="Smooth Corrective",
+    )
+    mask: bpy.props.BoolProperty(
+        default=True,
+        name="Mask",
+    )
+
+    @classmethod
+    def poll(cls, context):
+        active_object = context.active_object
+        return (
+            active_object is not None
+            and active_object.type == "MESH"
+            and any(
+                (mod.type == "CORRECTIVE_SMOOTH" and mod.vertex_group != sm_vg_name)
+                or (mod.type == "MASK" and mod.vertex_group != mask_vg_name)
+                for mod in active_object.modifiers
+            )
+        )
+
+    def execute(self, context):
+
+        if not (self.smooth_corrective or self.mask):
+            self.report(
+                {"WARNING"},
+                "MustardUI - No Modifier type selected",
+            )
+
+        sm_converted = 0
+        mask_converted = 0
+        if self.smooth_corrective:
+            sm_converted = optimize_modifiers(
+                context,
+                context.active_object,
+                "CORRECTIVE_SMOOTH",
+                sm_vg_name,
+                self.sm_influence,
+                self.preserve_modifiers,
+            )
+        if self.mask:
+            mask_converted = optimize_modifiers(
+                context,
+                context.active_object,
+                "MASK",
+                mask_vg_name,
+                self.sm_influence,
+                self.preserve_modifiers,
+            )
+
+        if sm_converted + mask_converted > 0:
+            self.report(
+                {"INFO"},
+                f"MustardUI - {sm_converted + mask_converted} Modifiers optimized",
+            )
+        else:
+            self.report(
+                {"WARNING"},
+                "MustardUI - No Modifiers needs to be optimized",
+            )
+
+        return {"FINISHED"}
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self, width=250)
+
+    def draw(self, context):
+        layout = self.layout
+
+        col = layout.column(align=True)
+        col.prop(self, "mask", icon="MOD_MASK")
+        col.prop(self, "smooth_corrective", icon="MOD_SMOOTH")
+
+        box = layout.box()
+        box.label(text="Settings", icon="PREFERENCES")
+        col = box.column(align=True)
+        col.prop(self, "preserve_modifiers")
+
+        row = col.row()
+        row.enabled = self.smooth_corrective
+        row.prop(self, "sm_influence")
+
+
+def register():
+    bpy.utils.register_class(MustardUI_ToolsCreators_OptimizeModifiers)
+
+
+def unregister():
+    bpy.utils.unregister_class(MustardUI_ToolsCreators_OptimizeModifiers)


### PR DESCRIPTION
- **Feature**: Tool to optimize Smooth Corrective and Mask modifiers with Vertex Mix Modifiers.

<img width="1634" height="1414" alt="Screen Recording 2026-05-15 at 20 47 23" src="https://github.com/user-attachments/assets/e946cc75-98f5-412f-a8e6-18e7901c9f7a" />

- **Feature**: SmartCheck option to auto-create the Vertex Weight Mix + Mask stack on the body mesh from vertex group names; or convert current Mask modifiers in Vertex Weight Mix modifiers (by @Ckang3D).
- **Fix (#357)**: VERTEX_WEIGHT_MIX modifiers are ignored by the global mask toggle (by @Ckang3D). 
- **Fix**: Pointer are overridden to "None" type when fixing paths.
- **Fix**: Presets error when a Default preset has been set.