### PR TITLE
Fix VERTEX_WEIGHT_MIX mask toggle + SmartCheck auto-setup for body mask modifiers (#357)

### DIFF
--- a/configuration/ops_smartcheck.py
+++ b/configuration/ops_smartcheck.py
@@ -4,11 +4,179 @@ from .. import __package__ as base_package
 from ..model_selection.active_object import mustardui_active_object
 
 
+def smartcheck_body_mask_from_vg(self, context, rig_settings):
+    warnings = 0
+
+    mask_vg_name = "MustardUI - Mask"
+
+    outfit_colls = [
+        x.collection for x in rig_settings.outfits_collections if x.collection
+    ]
+
+    body = rig_settings.model_body
+    if body is None:
+        warnings += 1
+        print(
+            "MustardUI Smart Check - Body Mask from Vertex Groups - "
+            "No Body Object found"
+        )
+        return warnings
+
+    arm_idx = next(
+        (i for i, m in enumerate(body.modifiers) if m.type == "ARMATURE"),
+        None,
+    )
+    if arm_idx is None:
+        warnings += 1
+        print(
+            "MustardUI Smart Check - Body Mask from Vertex Groups - No Armature on Body"
+        )
+        return warnings
+
+    all_colls = outfit_colls + (
+        [rig_settings.extras_collection] if rig_settings.extras_collection else []
+    )
+    obj_to_col = {o: c for c in all_colls for o in c.objects if o.type == "MESH"}
+
+    if len(obj_to_col) < 1:
+        warnings += 1
+        print(
+            "MustardUI Smart Check - Body Mask from Vertex Groups - "
+            "No Outfit added on the current model"
+        )
+        return warnings
+
+    if any(
+        mod.type in {"MASK", "VERTEX_WEIGHT_MIX"}
+        and outfit_obj.name in mod.name.split("|")
+        for outfit_obj in obj_to_col
+        for mod in body.modifiers
+    ):
+        rig_settings.outfits_enable_global_mask = True
+
+    if mask_vg_name not in body.vertex_groups:
+        body.vertex_groups.new(name=mask_vg_name)
+
+    insert_pos = arm_idx + 1 if arm_idx is not None else 0
+
+    # Temporarily set body as active for modifier_move_to_index
+    prev_active = context.view_layer.objects.active
+    context.view_layer.objects.active = body
+
+    outfits_with_mask = 0
+    for vg in body.vertex_groups:
+        mod = next(
+            (
+                m
+                for m in body.modifiers
+                if (m.type == "VERTEX_WEIGHT_MIX" and m.vertex_group_b == vg.name)
+                or (
+                    self.smartcheck_body_mask_optimize
+                    and m.type == "MASK"
+                    and m.vertex_group == vg.name
+                )
+            ),
+            None,
+        )
+
+        for outfit_obj, col in obj_to_col.items():
+            if outfit_obj.name not in vg.name.split("|"):
+                continue
+
+            outfits_with_mask += 1
+
+            if mod is None or (mod is not None and mod.type == "MASK"):
+                if mod is not None and mod.type == "MASK":
+                    body.modifiers.remove(mod)
+                mod = body.modifiers.new(name=vg.name, type="VERTEX_WEIGHT_MIX")
+                mod.vertex_group_a = mask_vg_name
+                mod.vertex_group_b = vg.name
+                mod.mix_set = "ALL"
+                mod.mix_mode = "ADD"
+                mod.show_expanded = False
+
+            is_active = col.name == rig_settings.outfits_list
+            is_locked = getattr(outfit_obj, "MustardUI_outfit_lock", False)
+            visible = (
+                (is_active or is_locked)
+                and not outfit_obj.hide_viewport
+                and rig_settings.outfits_global_mask
+            )
+            mod.show_viewport = visible
+            mod.show_render = visible
+            bpy.ops.object.modifier_move_to_index(modifier=mod.name, index=insert_pos)
+            insert_pos += 1
+            rig_settings.outfits_enable_global_mask = True
+            break  # first-match wins: one outfit per VG
+
+    if outfits_with_mask < 1:
+        warnings += 1
+        print(
+            "MustardUI Smart Check - Body Mask from Vertex Groups - "
+            "No valid Vertex Group to add"
+        )
+        return warnings
+
+    mask_mod = next(
+        (m for m in body.modifiers if m.type == "MASK" and m.name == mask_vg_name),
+        None,
+    )
+    if mask_mod is None:
+        mask_mod = body.modifiers.new(name=mask_vg_name, type="MASK")
+        mask_mod.vertex_group = mask_vg_name
+        mask_mod.invert_vertex_group = True
+        mask_mod.show_expanded = False
+        rig_settings.outfits_enable_global_mask = True
+
+    last_vwm = next(
+        (
+            i
+            for i, m in reversed(list(enumerate(body.modifiers)))
+            if m.type == "VERTEX_WEIGHT_MIX"
+        ),
+        -1,
+    )
+    target_mask = min(
+        last_vwm + 1 if last_vwm >= 0 else insert_pos,
+        len(body.modifiers) - 1,
+    )
+    current_mask_idx = next(
+        i
+        for i, m in enumerate(body.modifiers)
+        if m.name == mask_vg_name and m.type == "MASK"
+    )
+    if current_mask_idx != target_mask:
+        bpy.ops.object.modifier_move_to_index(modifier=mask_mod.name, index=target_mask)
+        print(
+            f"MustardUI Smart Check - Body Mask from Vertex Groups - "
+            f"Mask repositioned to index {target_mask}"
+        )
+
+    context.view_layer.objects.active = prev_active
+
+    subdiv_idx = None
+    mask_pos = None
+    for i, mod in enumerate(body.modifiers):
+        if mod.type == "SUBSURF" and subdiv_idx is None:
+            subdiv_idx = i
+        if mod.type == "MASK" and mod.name == mask_vg_name and mask_pos is None:
+            mask_pos = i
+    if subdiv_idx is not None and mask_pos is not None and subdiv_idx < mask_pos:
+        warnings += 1
+        print(
+            "MustardUI Smart Check - Body Mask from Vertex Groups - "
+            "The Subdivision modifier should be manually placed after "
+            "the Mask"
+        )
+
+    return warnings
+
+
 class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
     """Search for MustardUI configuration options based on the name of the model and its body"""  # noqa: E501
 
     bl_idname = "mustardui.configuration_smartcheck"
-    bl_label = "Smart Search."
+    bl_label = "Smart Check"
     bl_options = {"UNDO"}
 
     smartcheck_custom_properties: bpy.props.BoolProperty(
@@ -51,10 +219,17 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         "be added as a Global Setting.",
     )
     smartcheck_body_mask_from_vg: bpy.props.BoolProperty(
-        name="Body Mask from Vertex Groups",
+        name="Create Masks from Vertex Groups",
         default=True,
         description="Auto-create Vertex Weight Mix modifiers on the Body "
-        "by matching vertex group names with Outfit object names",
+        "by matching vertex group with Outfit Objects names",
+    )
+    smartcheck_body_mask_optimize: bpy.props.BoolProperty(
+        name="Optimize Mask modifiers",
+        default=True,
+        description="Replace Mask modifiers with Vertex Weight Mix modifiers.\n"
+        "This should greatly improve the performance of the model "
+        "when several Maks are used",
     )
 
     @classmethod
@@ -78,7 +253,7 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         rig_settings = obj.MustardUI_RigSettings
         addon_prefs = context.preferences.addons[base_package].preferences
 
-        warnings = []
+        warnings = 0
 
         # Try to assign the rig object
         if not obj.MustardUI_created:
@@ -285,138 +460,7 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
 
             # Auto-create VERTEX_WEIGHT_MIX from body VGs matching outfit objects
             if self.smartcheck_body_mask_from_vg:
-                body = rig_settings.model_body
-                if body is not None:
-                    all_colls = outfit_colls + (
-                        [rig_settings.extras_collection]
-                        if rig_settings.extras_collection
-                        else []
-                    )
-                    obj_to_col = {
-                        o: c for c in all_colls for o in c.objects if o.type == "MESH"
-                    }
-
-                    if any(
-                        mod.type in {"MASK", "VERTEX_WEIGHT_MIX"}
-                        and outfit_obj.name in mod.name.split("|")
-                        for outfit_obj in obj_to_col
-                        for mod in body.modifiers
-                    ):
-                        rig_settings.outfits_enable_global_mask = True
-
-                    mask_vg_name = "MustardUI - Mask"
-
-                    if mask_vg_name not in body.vertex_groups:
-                        body.vertex_groups.new(name=mask_vg_name)
-
-                    arm_idx = next(
-                        (
-                            i
-                            for i, m in enumerate(body.modifiers)
-                            if m.type == "ARMATURE"
-                        ),
-                        None,
-                    )
-                    if arm_idx is None:
-                        warnings.append("No Armature on body")
-                    insert_pos = arm_idx + 1 if arm_idx is not None else 0
-
-                    # Temporarily set body as active for modifier_move_to_index
-                    prev_active = context.view_layer.objects.active
-                    context.view_layer.objects.active = body
-
-                    for vg in body.vertex_groups:
-                        for outfit_obj, col in obj_to_col.items():
-                            if outfit_obj.name not in vg.name.split("|"):
-                                continue
-                            exists = any(
-                                m.type == "VERTEX_WEIGHT_MIX" and m.name == vg.name
-                                for m in body.modifiers
-                            )
-                            if not exists:
-                                mod = body.modifiers.new(
-                                    name=vg.name, type="VERTEX_WEIGHT_MIX"
-                                )
-                                mod.vertex_group_a = mask_vg_name
-                                mod.vertex_group_b = vg.name
-                                mod.mix_set = "ALL"
-                                mod.mix_mode = "ADD"
-                                mod.show_expanded = False
-                                is_active = col.name == rig_settings.outfits_list
-                                is_locked = getattr(
-                                    outfit_obj, "MustardUI_outfit_lock", False
-                                )
-                                visible = (
-                                    (is_active or is_locked)
-                                    and not outfit_obj.hide_viewport
-                                    and rig_settings.outfits_global_mask
-                                )
-                                mod.show_viewport = visible
-                                mod.show_render = visible
-                                bpy.ops.object.modifier_move_to_index(
-                                    modifier=mod.name, index=insert_pos
-                                )
-                                insert_pos += 1
-                                rig_settings.outfits_enable_global_mask = True
-                            break  # first-match wins: one outfit per VG
-
-                    mask_mod = next(
-                        (
-                            m
-                            for m in body.modifiers
-                            if m.type == "MASK" and m.name == mask_vg_name
-                        ),
-                        None,
-                    )
-                    if mask_mod is None:
-                        mask_mod = body.modifiers.new(name=mask_vg_name, type="MASK")
-                        mask_mod.vertex_group = mask_vg_name
-                        mask_mod.invert_vertex_group = True
-                        mask_mod.show_expanded = False
-                        rig_settings.outfits_enable_global_mask = True
-
-                    last_vwm = next(
-                        (
-                            i
-                            for i, m in reversed(list(enumerate(body.modifiers)))
-                            if m.type == "VERTEX_WEIGHT_MIX"
-                        ),
-                        -1,
-                    )
-                    target_mask = min(
-                        last_vwm + 1 if last_vwm >= 0 else insert_pos,
-                        len(body.modifiers) - 1,
-                    )
-                    current_mask_idx = next(
-                        i
-                        for i, m in enumerate(body.modifiers)
-                        if m.name == mask_vg_name
-                    )
-                    if current_mask_idx != target_mask:
-                        bpy.ops.object.modifier_move_to_index(
-                            modifier=mask_mod.name, index=target_mask
-                        )
-                        warnings.append(f"Mask repositioned to index {target_mask}")
-
-                    context.view_layer.objects.active = prev_active
-
-                    subdiv_idx = None
-                    mask_pos = None
-                    for i, mod in enumerate(body.modifiers):
-                        if mod.type == "SUBSURF" and subdiv_idx is None:
-                            subdiv_idx = i
-                        if (
-                            mod.type == "MASK"
-                            and mod.name == mask_vg_name
-                            and mask_pos is None
-                        ):
-                            mask_pos = i
-                    if (
-                        subdiv_idx is not None
-                        and mask_pos is not None
-                        and subdiv_idx < mask_pos
-                    ):
-                        warnings.append("Move Subdivision after Mask")
+                warnings += smartcheck_body_mask_from_vg(self, context, rig_settings)
 
             # Hair
             if rig_settings.hair_collection is not None:
@@ -451,7 +495,8 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         if warnings:
             self.report(
                 {"WARNING"},
-                "MustardUI - Smart Check done. " + " | ".join(warnings),
+                "MustardUI - Smart Check generated Warnings. See the Console for more"
+                " information.",
             )
         else:
             self.report({"INFO"}, "MustardUI - Smart Check complete.")
@@ -469,7 +514,7 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         layout = self.layout
 
         box = layout.box()
-        box.label(text="Categories to Smart Check")
+        box.label(text="Categories", icon="DUPLICATE")
         col = box.column()
         col.prop(self, "smartcheck_outfits")
 
@@ -479,13 +524,13 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         row.label(text="", icon="BLANK1")
         row.prop(self, "reset_current_collections")
 
-        col.separator()
         col.prop(self, "smartcheck_settings")
-        row = col.row(align=True)
-        row.enabled = self.smartcheck_settings
-        row.label(text="", icon="BLANK1")
-        row.prop(self, "smartcheck_body_mask_from_vg")
-        col.prop(self, "smartcheck_custom_properties")
+
+        box = layout.box()
+        box.label(text="Mask", icon="MOD_MASK")
+        col = box.column(align=True)
+        col.prop(self, "smartcheck_body_mask_from_vg")
+        col.prop(self, "smartcheck_body_mask_optimize")
 
 
 def register():

--- a/configuration/ops_smartcheck.py
+++ b/configuration/ops_smartcheck.py
@@ -53,7 +53,7 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
     smartcheck_body_mask_from_vg: bpy.props.BoolProperty(
         name="Body Mask from Vertex Groups",
         default=True,
-        description="Auto-create VERTEX_WEIGHT_MIX modifiers on the Body "
+        description="Auto-create Vertex Weight Mix modifiers on the Body "
         "by matching vertex group names with Outfit object names",
     )
 

--- a/configuration/ops_smartcheck.py
+++ b/configuration/ops_smartcheck.py
@@ -50,6 +50,12 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         "on the Body Object or in the Outfits/Extras/Hair, it will "
         "be added as a Global Setting.",
     )
+    smartcheck_body_mask_from_vg: bpy.props.BoolProperty(
+        name="Body Mask from Vertex Groups",
+        default=True,
+        description="Auto-create VERTEX_WEIGHT_MIX modifiers on the Body "
+        "by matching vertex group names with Outfit object names",
+    )
 
     @classmethod
     def poll(cls, context):
@@ -71,6 +77,8 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         res, obj = mustardui_active_object(context, config=1)
         rig_settings = obj.MustardUI_RigSettings
         addon_prefs = context.preferences.addons[base_package].preferences
+
+        warnings = []
 
         # Try to assign the rig object
         if not obj.MustardUI_created:
@@ -275,6 +283,115 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                     elif m.type == "TRIANGULATE":
                         rig_settings.outfits_enable_global_triangulate = True
 
+            # Auto-create VERTEX_WEIGHT_MIX from body VGs matching outfit objects
+            if self.smartcheck_body_mask_from_vg:
+                body = rig_settings.model_body
+                if body is not None:
+                    obj_to_col = {}
+                    for c in outfit_colls:
+                        for outfit_obj in [x for x in c.objects if x.type == "MESH"]:
+                            obj_to_col[outfit_obj] = c
+                    if rig_settings.extras_collection is not None:
+                        for outfit_obj in [
+                            x for x in rig_settings.extras_collection.objects if x.type == "MESH"
+                        ]:
+                            obj_to_col[outfit_obj] = rig_settings.extras_collection
+
+                    if any(
+                        mod.type in {"MASK", "VERTEX_WEIGHT_MIX"} and outfit_obj.name in mod.name.split("|")
+                        for outfit_obj in obj_to_col
+                        for mod in body.modifiers
+                    ):
+                        rig_settings.outfits_enable_global_mask = True
+
+                    mask_vg_name = "MustardUI - Mask"
+
+                    if mask_vg_name not in body.vertex_groups:
+                        body.vertex_groups.new(name=mask_vg_name)
+
+                    insert_pos = 0
+                    armature_found = False
+                    for i, mod in enumerate(body.modifiers):
+                        if mod.type == "ARMATURE":
+                            insert_pos = i + 1
+                            armature_found = True
+                            break
+                    if not armature_found:
+                        warnings.append("No Armature modifier found on body; VWM modifiers inserted at stack top")
+
+                    # Temporarily set body as active for modifier_move_to_index
+                    prev_active = context.view_layer.objects.active
+                    context.view_layer.objects.active = body
+
+                    for vg in body.vertex_groups:
+                        for outfit_obj, col in obj_to_col.items():
+                            if outfit_obj.name not in vg.name.split("|"):
+                                continue
+                            exists = any(
+                                m.type == "VERTEX_WEIGHT_MIX" and m.name == vg.name
+                                for m in body.modifiers
+                            )
+                            if not exists:
+                                mod = body.modifiers.new(name=vg.name, type="VERTEX_WEIGHT_MIX")
+                                mod.vertex_group_a = mask_vg_name
+                                mod.vertex_group_b = vg.name
+                                mod.mix_set = "ALL"
+                                mod.mix_mode = "ADD"
+                                mod.show_expanded = False
+                                is_active = col.name == rig_settings.outfits_list
+                                is_locked = getattr(outfit_obj, "MustardUI_outfit_lock", False)
+                                visible = (is_active or is_locked) and not outfit_obj.hide_viewport and rig_settings.outfits_global_mask
+                                mod.show_viewport = visible
+                                mod.show_render = visible
+                                bpy.ops.object.modifier_move_to_index(
+                                    modifier=mod.name, index=insert_pos
+                                )
+                                insert_pos += 1
+                                rig_settings.outfits_enable_global_mask = True
+                            break  # first-match wins: each VG is assigned to one outfit object
+
+                    mask_mod = next(
+                        (m for m in body.modifiers if m.type == "MASK" and m.name == mask_vg_name),
+                        None,
+                    )
+                    if mask_mod is None:
+                        mask_mod = body.modifiers.new(name=mask_vg_name, type="MASK")
+                        mask_mod.vertex_group = mask_vg_name
+                        mask_mod.invert_vertex_group = True
+                        mask_mod.show_expanded = False
+                        rig_settings.outfits_enable_global_mask = True
+
+                    last_vwm = -1
+                    for i, mod in enumerate(body.modifiers):
+                        if mod.type == "VERTEX_WEIGHT_MIX":
+                            last_vwm = i
+                    target_mask = min(
+                        last_vwm + 1 if last_vwm >= 0 else insert_pos,
+                        len(body.modifiers) - 1,
+                    )
+                    current_mask_idx = list(body.modifiers).index(mask_mod)
+                    if current_mask_idx != target_mask:
+                        bpy.ops.object.modifier_move_to_index(
+                            modifier=mask_mod.name, index=target_mask
+                        )
+                        warnings.append(
+                            f"Mask modifier moved to index {target_mask} (after last VERTEX_WEIGHT_MIX)"
+                        )
+
+                    context.view_layer.objects.active = prev_active
+
+                    subdiv_idx = None
+                    mask_pos = None
+                    for i, mod in enumerate(body.modifiers):
+                        if mod.type == "SUBSURF" and subdiv_idx is None:
+                            subdiv_idx = i
+                        if mod.type == "MASK" and mod.name == mask_vg_name and mask_pos is None:
+                            mask_pos = i
+                    if subdiv_idx is not None and mask_pos is not None and subdiv_idx < mask_pos:
+                        warnings.append(
+                            "Subdivision modifier should be placed after Mask modifier"
+                        )
+
             # Hair
             if rig_settings.hair_collection is not None:
                 objects = []
@@ -305,7 +422,13 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
         if addon_prefs.debug:
             print("\nMustardUI - Smart Check - End")
 
-        self.report({"INFO"}, "MustardUI - Smart Check complete.")
+        if warnings:
+            self.report(
+                {"WARNING"},
+                "MustardUI - Smart Check done. " + " | ".join(warnings),
+            )
+        else:
+            self.report({"INFO"}, "MustardUI - Smart Check complete.")
 
         return {"FINISHED"}
 
@@ -332,6 +455,10 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
 
         col.separator()
         col.prop(self, "smartcheck_settings")
+        row = col.row(align=True)
+        row.enabled = self.smartcheck_settings
+        row.label(text="", icon="BLANK1")
+        row.prop(self, "smartcheck_body_mask_from_vg")
         col.prop(self, "smartcheck_custom_properties")
 
 

--- a/configuration/ops_smartcheck.py
+++ b/configuration/ops_smartcheck.py
@@ -287,18 +287,18 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
             if self.smartcheck_body_mask_from_vg:
                 body = rig_settings.model_body
                 if body is not None:
-                    obj_to_col = {}
-                    for c in outfit_colls:
-                        for outfit_obj in [x for x in c.objects if x.type == "MESH"]:
-                            obj_to_col[outfit_obj] = c
-                    if rig_settings.extras_collection is not None:
-                        for outfit_obj in [
-                            x for x in rig_settings.extras_collection.objects if x.type == "MESH"
-                        ]:
-                            obj_to_col[outfit_obj] = rig_settings.extras_collection
+                    all_colls = outfit_colls + (
+                        [rig_settings.extras_collection]
+                        if rig_settings.extras_collection
+                        else []
+                    )
+                    obj_to_col = {
+                        o: c for c in all_colls for o in c.objects if o.type == "MESH"
+                    }
 
                     if any(
-                        mod.type in {"MASK", "VERTEX_WEIGHT_MIX"} and outfit_obj.name in mod.name.split("|")
+                        mod.type in {"MASK", "VERTEX_WEIGHT_MIX"}
+                        and outfit_obj.name in mod.name.split("|")
                         for outfit_obj in obj_to_col
                         for mod in body.modifiers
                     ):
@@ -309,15 +309,17 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                     if mask_vg_name not in body.vertex_groups:
                         body.vertex_groups.new(name=mask_vg_name)
 
-                    insert_pos = 0
-                    armature_found = False
-                    for i, mod in enumerate(body.modifiers):
-                        if mod.type == "ARMATURE":
-                            insert_pos = i + 1
-                            armature_found = True
-                            break
-                    if not armature_found:
-                        warnings.append("No Armature modifier found on body; VWM modifiers inserted at stack top")
+                    arm_idx = next(
+                        (
+                            i
+                            for i, m in enumerate(body.modifiers)
+                            if m.type == "ARMATURE"
+                        ),
+                        None,
+                    )
+                    if arm_idx is None:
+                        warnings.append("No Armature on body")
+                    insert_pos = arm_idx + 1 if arm_idx is not None else 0
 
                     # Temporarily set body as active for modifier_move_to_index
                     prev_active = context.view_layer.objects.active
@@ -332,15 +334,23 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                                 for m in body.modifiers
                             )
                             if not exists:
-                                mod = body.modifiers.new(name=vg.name, type="VERTEX_WEIGHT_MIX")
+                                mod = body.modifiers.new(
+                                    name=vg.name, type="VERTEX_WEIGHT_MIX"
+                                )
                                 mod.vertex_group_a = mask_vg_name
                                 mod.vertex_group_b = vg.name
                                 mod.mix_set = "ALL"
                                 mod.mix_mode = "ADD"
                                 mod.show_expanded = False
                                 is_active = col.name == rig_settings.outfits_list
-                                is_locked = getattr(outfit_obj, "MustardUI_outfit_lock", False)
-                                visible = (is_active or is_locked) and not outfit_obj.hide_viewport and rig_settings.outfits_global_mask
+                                is_locked = getattr(
+                                    outfit_obj, "MustardUI_outfit_lock", False
+                                )
+                                visible = (
+                                    (is_active or is_locked)
+                                    and not outfit_obj.hide_viewport
+                                    and rig_settings.outfits_global_mask
+                                )
                                 mod.show_viewport = visible
                                 mod.show_render = visible
                                 bpy.ops.object.modifier_move_to_index(
@@ -348,10 +358,14 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                                 )
                                 insert_pos += 1
                                 rig_settings.outfits_enable_global_mask = True
-                            break  # first-match wins: each VG is assigned to one outfit object
+                            break  # first-match wins: one outfit per VG
 
                     mask_mod = next(
-                        (m for m in body.modifiers if m.type == "MASK" and m.name == mask_vg_name),
+                        (
+                            m
+                            for m in body.modifiers
+                            if m.type == "MASK" and m.name == mask_vg_name
+                        ),
                         None,
                     )
                     if mask_mod is None:
@@ -361,22 +375,28 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                         mask_mod.show_expanded = False
                         rig_settings.outfits_enable_global_mask = True
 
-                    last_vwm = -1
-                    for i, mod in enumerate(body.modifiers):
-                        if mod.type == "VERTEX_WEIGHT_MIX":
-                            last_vwm = i
+                    last_vwm = next(
+                        (
+                            i
+                            for i, m in reversed(list(enumerate(body.modifiers)))
+                            if m.type == "VERTEX_WEIGHT_MIX"
+                        ),
+                        -1,
+                    )
                     target_mask = min(
                         last_vwm + 1 if last_vwm >= 0 else insert_pos,
                         len(body.modifiers) - 1,
                     )
-                    current_mask_idx = list(body.modifiers).index(mask_mod)
+                    current_mask_idx = next(
+                        i
+                        for i, m in enumerate(body.modifiers)
+                        if m.name == mask_vg_name
+                    )
                     if current_mask_idx != target_mask:
                         bpy.ops.object.modifier_move_to_index(
                             modifier=mask_mod.name, index=target_mask
                         )
-                        warnings.append(
-                            f"Mask modifier moved to index {target_mask} (after last VERTEX_WEIGHT_MIX)"
-                        )
+                        warnings.append(f"Mask repositioned to index {target_mask}")
 
                     context.view_layer.objects.active = prev_active
 
@@ -385,12 +405,18 @@ class MustardUI_Configuration_SmartCheck(bpy.types.Operator):
                     for i, mod in enumerate(body.modifiers):
                         if mod.type == "SUBSURF" and subdiv_idx is None:
                             subdiv_idx = i
-                        if mod.type == "MASK" and mod.name == mask_vg_name and mask_pos is None:
+                        if (
+                            mod.type == "MASK"
+                            and mod.name == mask_vg_name
+                            and mask_pos is None
+                        ):
                             mask_pos = i
-                    if subdiv_idx is not None and mask_pos is not None and subdiv_idx < mask_pos:
-                        warnings.append(
-                            "Subdivision modifier should be placed after Mask modifier"
-                        )
+                    if (
+                        subdiv_idx is not None
+                        and mask_pos is not None
+                        and subdiv_idx < mask_pos
+                    ):
+                        warnings.append("Move Subdivision after Mask")
 
             # Hair
             if rig_settings.hair_collection is not None:

--- a/settings/rig.py
+++ b/settings/rig.py
@@ -440,7 +440,7 @@ class MustardUI_RigSettings(bpy.types.PropertyGroup):
                     continue
 
                 for mod in self.model_body.modifiers:
-                    if mod.type != "MASK":
+                    if mod.type not in {"MASK", "VERTEX_WEIGHT_MIX"}:
                         continue
                     if not self.outfits_enable_global_mask:
                         continue


### PR DESCRIPTION
● Fix `VERTEX_WEIGHT_MIX` modifiers being ignored by the global mask toggle, and add a SmartCheck option to auto-create the `VERTEX_WEIGHT_MIX` + `MASK` stack on the body mesh from vertex
  group names.
  
  #357 