### PR TITLE
Guard poll() against None active_object in optimize_shaders and select_preview_texture

### DIFF
--- a/tools_creators/ops_optimize_shaders.py
+++ b/tools_creators/ops_optimize_shaders.py
@@ -232,7 +232,8 @@ class MustardUI_ToolsCreators_OptimizeShaders(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.type == "MESH"
+        obj = context.active_object
+        return obj is not None and obj.type == "MESH"
 
     def execute(self, context):
 

--- a/tools_creators/ops_optimize_shaders.py
+++ b/tools_creators/ops_optimize_shaders.py
@@ -232,7 +232,7 @@ class MustardUI_ToolsCreators_OptimizeShaders(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object.type == "MESH"
+        return context.active_object is not None and context.active_object.type == "MESH"
 
     def execute(self, context):
 

--- a/tools_creators/ops_select_preview_texture.py
+++ b/tools_creators/ops_select_preview_texture.py
@@ -121,7 +121,7 @@ class MustardUI_ToolsCreators_SelectPreviewTexture(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object.type == "MESH"
+        return context.active_object is not None and context.active_object.type == "MESH"
 
     def execute(self, context):
 

--- a/tools_creators/ops_select_preview_texture.py
+++ b/tools_creators/ops_select_preview_texture.py
@@ -121,7 +121,8 @@ class MustardUI_ToolsCreators_SelectPreviewTexture(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None and context.active_object.type == "MESH"
+        obj = context.active_object
+        return obj is not None and obj.type == "MESH"
 
     def execute(self, context):
 


### PR DESCRIPTION
Guard poll() against None active_object in optimize_shaders and select_preview_texture

Both operators called context.active_object.type without first checking that context.active_object is not None, causing an AttributeError when no object is selected.

https://claude.ai/code/session_011cokxCFccXF4rR7prWTCB5