### PR TITLE
Refactor hair selection restoration into utility functions

### DIFF
--- a/configuration/ops_configuration.py
+++ b/configuration/ops_configuration.py
@@ -4,6 +4,7 @@ import bpy
 
 from .. import __package__ as base_package
 from .. import bl_info
+from ..hair.helper_functions import set_selected_hair, store_current_hair
 from ..model_selection.active_object import mustardui_active_object
 from ..physics.update_enable import enable_physics_update
 
@@ -187,9 +188,8 @@ class MustardUI_Configuration(bpy.types.Operator):
                     > 0
                 ):
                     try:
-                        rig_settings.hair_list = rig_settings.hair_list_make(context)[
-                            0
-                        ][0]
+                        object_active = store_current_hair(rig_settings)
+                        set_selected_hair(context, rig_settings, object_active)
                         print(
                             "MustardUI - Configuration Warning - Fixed hair_list index"
                         )

--- a/hair/helper_functions.py
+++ b/hair/helper_functions.py
@@ -1,0 +1,27 @@
+def store_current_hair(rig_settings):
+    """Return the name of the currently visible hair object, or '' if none found."""
+    if rig_settings.hair_collection is None:
+        return ""
+    for obj in rig_settings.hair_collection.objects:
+        if (
+            obj is not None
+            and not obj.hide_viewport
+            and not obj.hide_render
+            and obj.type in ["MESH", "CURVES"]
+        ):
+            return obj.name
+    return ""
+
+
+def set_selected_hair(context, rig_settings, object_active):
+    """Set hair_list to object_active, falling back to the first element if needed."""
+    hlist = rig_settings.hair_list_make(context)
+    if not hlist:
+        return
+    if object_active:
+        try:
+            rig_settings.hair_list = object_active
+        except Exception:
+            rig_settings.hair_list = hlist[0][0]
+    else:
+        rig_settings.hair_list = hlist[0][0]

--- a/warnings/ops_update_ui.py
+++ b/warnings/ops_update_ui.py
@@ -3,6 +3,7 @@ import bpy
 from .. import __package__ as base_package
 from .. import bl_info
 from ..custom_properties.misc import assign_pointers
+from ..hair.helper_functions import set_selected_hair, store_current_hair
 from ..model_selection.active_object import mustardui_active_object
 
 
@@ -195,9 +196,6 @@ class MustardUI_UpdateUI(bpy.types.Operator):
                 hair_collection = rig_settings.hair_collection
 
                 # Rename the Objects in the Hair collection
-                # Store the active object to try to use it as the hair list selection
-                # after the update
-                object_active = ""
                 for i, obj in enumerate(
                     [x for x in hair_collection.objects if x is not None]
                 ):
@@ -205,32 +203,10 @@ class MustardUI_UpdateUI(bpy.types.Operator):
                         obj_name = obj.name
                         obj_name = update_hair_name(obj_name)
                         obj.name = obj_name
-                    if (
-                        not obj.hide_viewport
-                        and not obj.hide_render
-                        and obj.type == "MESH"
-                    ):
-                        object_active = obj.name
 
-                # Fix the list index
-                hlist = rig_settings.hair_list_make(context)
-                # Try first if there was an active object
-                if object_active != "":
-                    try:
-                        rig_settings.hair_list = object_active
-                        # Also show the Armature
-                        for obj in hair_collection.objects:
-                            if obj.name == rig_settings.hair_list:
-                                parent_armature = None
-                                if parent_armature is not None:
-                                    parent_armature.hide_viewport = False
-                                    parent_armature.hide_render = False
-                                break
-                    except Exception:
-                        rig_settings.hair_list = hlist[0][0]
-                # Otherwise fix the list index with the first element in the list
-                else:
-                    rig_settings.hair_list = hlist[0][0]
+                # Fix the list index, restoring the previously active hair
+                object_active = store_current_hair(rig_settings)
+                set_selected_hair(context, rig_settings, object_active)
 
                 rig_settings.model_mustardui_version = bl_info["version"]
             except Exception:


### PR DESCRIPTION
Fixes #370

Add `store_current_hair()` and `set_selected_hair()` in `hair/helper_functions.py` and use them in both `configuration/ops_configuration.py` and `warnings/ops_update_ui.py`, fixing the bug where `hair_list` resets to index 0 after entering/leaving configuration mode.

Generated with [Claude Code](https://claude.ai/code)