### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Formatting and Linting


### PR DESCRIPTION
Potential fix for [https://github.com/Mustard2/MustardUI/security/code-scanning/1](https://github.com/Mustard2/MustardUI/security/code-scanning/1)

To fix this, add an explicit top-level `permissions` block in `.github/workflows/workflows.yml` so all jobs in this workflow get least-privilege token access by default.

Best single fix here: add:

- `permissions:`
  - `contents: read`

directly under the `on:` trigger section (before `jobs:`). This matches CodeQL’s recommended minimal baseline and preserves existing behavior for checkout/linting while preventing unexpected write scope from repo/org defaults.

No imports, methods, or dependency changes are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
