### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Formatting and Linting


### PR DESCRIPTION
Potential fix for [https://github.com/Mustard2/MustardUI/security/code-scanning/2](https://github.com/Mustard2/MustardUI/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root in `.github/workflows/workflows.yml` so all jobs inherit least-privilege defaults unless overridden.  
Best minimal fix without changing functionality: set:

- `contents: read`

This is typically sufficient for checkout/lint/build workflows that do not need write access. It addresses the CodeQL finding while preserving behavior.

Change region: directly after the `on:` trigger block and before `jobs:` in `.github/workflows/workflows.yml`.

No imports, methods, or additional definitions are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
