### PR TITLE
Refactor visibility and tag updates to support recursive application

### DIFF
--- a/outfits/ops_visibility.py
+++ b/outfits/ops_visibility.py
@@ -183,6 +183,21 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
                     {"WARNING"}, "MustardUI - Outfit Body has not been specified."
                 )
 
+        _MAX_DEPTH = 3
+
+        def apply_visibility_recursive(o, depth=0):
+            apply_visibility(o)
+            if depth < _MAX_DEPTH:
+                for child in o.children:
+                    if child.hide_viewport != o.hide_viewport:
+                        apply_visibility_recursive(child, depth + 1)
+
+        def update_tags_recursive(o, depth=0):
+            o.update_tag()
+            if depth < _MAX_DEPTH:
+                for child in o.children:
+                    update_tags_recursive(child, depth + 1)
+
         # Apply to main object
         apply_visibility(obj)
 
@@ -190,7 +205,7 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
         if self.shift:
             for child in obj.children:
                 if child.hide_viewport != obj.hide_viewport:
-                    apply_visibility(child)
+                    apply_visibility_recursive(child, depth=1)
 
         # ------------------- GLOBAL UPDATES ------------------- #
         # Physics update
@@ -200,9 +215,7 @@ class MustardUI_OutfitVisibility(bpy.types.Operator):
         # Update tags
         if rig_settings.outfits_update_tag_on_switch:
             arm.update_tag()
-            obj.update_tag()
-            for child in obj.children:
-                child.update_tag()
+            update_tags_recursive(obj)
 
         # Extras collection visibility
         extras = rig_settings.extras_collection


### PR DESCRIPTION
## Summary
This change refactors the visibility and tag update logic in the outfit visibility system to support recursive application through the object hierarchy with a depth limit, improving consistency when applying changes to nested objects.

## Key Changes
- Added `_MAX_DEPTH` constant (set to 3) to limit recursion depth and prevent infinite loops
- Introduced `apply_visibility_recursive()` function that recursively applies visibility changes to child objects up to the maximum depth, only processing children whose visibility state differs from the parent
- Introduced `update_tags_recursive()` function that recursively updates tags on objects and their children up to the maximum depth
- Updated shift+click behavior to use `apply_visibility_recursive()` instead of directly calling `apply_visibility()` on immediate children, enabling multi-level hierarchy support
- Simplified tag update logic by replacing manual iteration over direct children with a call to `update_tags_recursive()`, reducing code duplication

## Implementation Details
- The recursive functions check `depth < _MAX_DEPTH` before processing children, ensuring the recursion terminates safely
- `apply_visibility_recursive()` only processes children whose `hide_viewport` state differs from the parent, avoiding unnecessary processing of already-synchronized objects
- Both recursive functions maintain the same core logic as their non-recursive counterparts while extending support to nested hierarchies

https://claude.ai/code/session_017ye4VpFCdrJHaqbmTffcXL